### PR TITLE
Remove unnecessary `const_panic`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ criterion = { git = "https://github.com/bheisler/criterion.rs", rev = "6929f48e4
 encase_derive = { version = "=0.2.1", path = "derive" }
 
 thiserror = { version = "1", default-features = false }
-const_panic = { version = "0.2", default-features = false }
 
 mint = { version = "0.5.9", default-features = false, optional = true }
 cgmath = { version = "0.18", default-features = false, optional = true }

--- a/benches/troughput.rs
+++ b/benches/troughput.rs
@@ -102,8 +102,9 @@ fn gen_a(rng: &mut rand::rngs::StdRng) -> A {
     }
 }
 
-const _: () = const_panic::concat_assert!(
-    A::METADATA.min_size().get() == 4096,
+const _: () = assert_eq!(
+    A::METADATA.min_size().get(),
+    4096,
     A::METADATA.min_size().get()
 );
 

--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -296,9 +296,9 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
                         #[allow(clippy::extra_unused_lifetimes)]
                         const fn check #impl_generics () {
                             let alignment = <#ty as #root::ShaderType>::METADATA.alignment().get();
-                            #root::concat_assert!(
+                            ::core::assert!(
                                 alignment <= #align,
-                                "align attribute value must be at least ", alignment, " (field's type alignment)"
+                                "align attribute value must be at least {} (field's type alignment)", alignment
                             )
                         }
                         check();
@@ -320,7 +320,7 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
                         #[allow(clippy::extra_unused_lifetimes)]
                         const fn check #impl_generics () {
                             let size = <#ty as #root::Size>::SIZE.get();
-                            #root::concat_assert!(
+                            ::core::assert!(
                                 size <= #size,
                                 "size attribute value must be at least ", size, " (field's type size)"
                             )
@@ -344,10 +344,10 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
             {
                 let offset = <Self as #root::ShaderType>::METADATA.offset(#i);
 
-                #root::concat_assert!(
+                ::core::assert!(
                     min_alignment.is_aligned(offset),
-                    "offset of field '", #name, "' must be a multiple of ", min_alignment.get(),
-                    " (current offset: ", offset, ")"
+                    "offset of field '{}' must be a multiple of {} (current offset: {})",
+                    #name, min_alignment.get(), offset
                 )
             }
         };
@@ -366,10 +366,10 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
                     let prev_size = <#prev_field_ty as #root::Size>::SIZE.get();
                     let prev_size = min_alignment.round_up(prev_size);
 
-                    #root::concat_assert!(
+                    ::core::assert!(
                         diff >= prev_size,
-                        "offset between fields '", #prev_ident_name, "' and '", #name, "' must be at least ",
-                        min_alignment.get(), " (currently: ", diff, ")"
+                        "offset between fields '{}' and '{}' must be at least {} (currently: {})",
+                        #prev_ident_name, #name, min_alignment.get(), diff
                     )
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,5 +165,4 @@ pub mod private {
     pub use super::CalculateSizeFor;
     pub use super::ShaderType;
     pub use super::Size;
-    pub use const_panic::concat_assert;
 }

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -44,13 +44,11 @@ impl<T: ShaderType + Size, const N: usize> ShaderType for [T; N] {
         crate::utils::consume_zsts([
             <T as ShaderType>::UNIFORM_COMPAT_ASSERT(),
             if let Some(min_alignment) = Self::METADATA.uniform_min_alignment() {
-                const_panic::concat_assert!(
+                assert!(
                     min_alignment.is_aligned(Self::METADATA.stride().get()),
-                    "array stride must be a multiple of ",
+                    "array stride must be a multiple of {} (current stride: {})",
                     min_alignment.get(),
-                    " (current stride: ",
                     Self::METADATA.stride().get(),
-                    ")"
                 )
             },
         ])


### PR DESCRIPTION
`encase` already requires Rust version 1.57, which allows [panicking in constant evaluation](https://github.com/rust-lang/rust/blob/master/RELEASES.md#language-5). So the dependency is unnecessary.