### PR TITLE
Avoid `clippy::missing_const_for_fn`

### DIFF
--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -653,7 +653,7 @@ fn generate_field_trait_constraints<'a>(
 
         quote_spanned! {ty.span()=>
             const _: fn() = || {
-                #[allow(clippy::extra_unused_lifetimes)]
+                #[allow(clippy::extra_unused_lifetimes, clippy::missing_const_for_fn)]
                 fn check #impl_generics () #where_clause {
                     fn assert_impl<T: ?::core::marker::Sized + #t>() {}
                     assert_impl::<#ty>();


### PR DESCRIPTION
As in the title. Actually not a libraries responsibility, I would count that as a false-positive on Clippy's part.

See https://github.com/rust-lang/rust-clippy/issues/8854.