### PR TITLE
Rename `Size::SIZE` to `ShaderSize::SHADER_SIZE`

### DIFF
--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -59,7 +59,7 @@ pub trait ShaderType {
     ///
     /// For [WGSL fixed-footprint types](https://gpuweb.github.io/gpuweb/wgsl/#fixed-footprint-types)
     /// it represents [WGSL Size](https://gpuweb.github.io/gpuweb/wgsl/#alignment-and-size)
-    /// (equivalent to [`Size::SIZE`])
+    /// (equivalent to [`ShaderSize::SHADER_SIZE`])
     ///
     /// For
     /// [WGSL runtime-sized arrays](https://gpuweb.github.io/gpuweb/wgsl/#runtime-sized) and
@@ -73,7 +73,7 @@ pub trait ShaderType {
     /// Returns the size of `Self` at runtime
     ///
     /// For [WGSL fixed-footprint types](https://gpuweb.github.io/gpuweb/wgsl/#fixed-footprint-types)
-    /// it's equivalent to [`Self::min_size`] and [`Size::SIZE`]
+    /// it's equivalent to [`Self::min_size`] and [`ShaderSize::SHADER_SIZE`]
     fn size(&self) -> NonZeroU64 {
         Self::METADATA.min_size().0
     }
@@ -202,9 +202,9 @@ pub trait ShaderType {
 }
 
 /// Trait implemented for all [WGSL fixed-footprint types](https://gpuweb.github.io/gpuweb/wgsl/#fixed-footprint-types)
-pub trait Size: ShaderType {
+pub trait ShaderSize: ShaderType {
     /// Represents [WGSL Size](https://gpuweb.github.io/gpuweb/wgsl/#alignment-and-size) (equivalent to [`ShaderType::min_size`])
-    const SIZE: NonZeroU64 = Self::METADATA.min_size().0;
+    const SHADER_SIZE: NonZeroU64 = Self::METADATA.min_size().0;
 }
 
 /// Trait implemented for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,13 +78,13 @@
 /// Complex
 ///
 /// ```
-/// # use crate::encase::ShaderType;
+/// # use crate::encase::{ShaderType, ShaderSize};
 /// #[derive(ShaderType)]
 /// struct Complex<
 ///     'a,
 ///     'b: 'a,
-///     E: 'a + ShaderType + encase::Size,
-///     T: 'b + ShaderType + encase::Size,
+///     E: 'a + ShaderType + ShaderSize,
+///     T: 'b + ShaderType + ShaderSize,
 ///     const N: usize,
 /// > {
 ///     array: [&'a mut E; N],
@@ -103,8 +103,8 @@ mod types;
 mod impls;
 
 pub use crate::core::{
-    CalculateSizeFor, DynamicStorageBuffer, DynamicUniformBuffer, ShaderType, Size, StorageBuffer,
-    UniformBuffer,
+    CalculateSizeFor, DynamicStorageBuffer, DynamicUniformBuffer, ShaderSize, ShaderType,
+    StorageBuffer, UniformBuffer,
 };
 pub use types::runtime_sized_array::ArrayLength;
 
@@ -163,7 +163,7 @@ pub mod private {
     pub use super::utils::consume_zsts;
     pub use super::utils::ArrayExt;
     pub use super::CalculateSizeFor;
+    pub use super::ShaderSize;
     pub use super::ShaderType;
-    pub use super::Size;
     pub use const_panic::concat_assert;
 }

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -1,6 +1,6 @@
 use crate::core::{
-    BufferMut, BufferRef, CreateFrom, Metadata, ReadFrom, Reader, ShaderType, Size, SizeValue,
-    WriteInto, Writer,
+    BufferMut, BufferRef, CreateFrom, Metadata, ReadFrom, Reader, ShaderSize, ShaderType,
+    SizeValue, WriteInto, Writer,
 };
 
 pub struct ArrayMetadata {
@@ -18,11 +18,11 @@ impl Metadata<ArrayMetadata> {
     }
 }
 
-impl<T: ShaderType + Size, const N: usize> ShaderType for [T; N] {
+impl<T: ShaderType + ShaderSize, const N: usize> ShaderType for [T; N] {
     type ExtraMetadata = ArrayMetadata;
     const METADATA: Metadata<Self::ExtraMetadata> = {
         let alignment = T::METADATA.alignment();
-        let el_size = SizeValue::from(T::SIZE);
+        let el_size = SizeValue::from(T::SHADER_SIZE);
 
         let stride = alignment.round_up_size(el_size);
         let el_padding = alignment.padding_needed_for(el_size.get());
@@ -57,7 +57,7 @@ impl<T: ShaderType + Size, const N: usize> ShaderType for [T; N] {
     };
 }
 
-impl<T: Size, const N: usize> Size for [T; N] {}
+impl<T: ShaderSize, const N: usize> ShaderSize for [T; N] {}
 
 impl<T: WriteInto, const N: usize> WriteInto for [T; N]
 where

--- a/src/types/matrix.rs
+++ b/src/types/matrix.rs
@@ -125,11 +125,11 @@ macro_rules! impl_matrix_inner {
 
         impl<$($generics)*> $crate::private::ShaderType for $type
         where
-            $el_ty: $crate::private::Size,
+            $el_ty: $crate::private::ShaderSize,
         {
             type ExtraMetadata = $crate::private::MatrixMetadata;
             const METADATA: $crate::private::Metadata<Self::ExtraMetadata> = {
-                let col_size = $crate::private::SizeValue::from(<$el_ty as $crate::private::Size>::SIZE).mul($r);
+                let col_size = $crate::private::SizeValue::from(<$el_ty as $crate::private::ShaderSize>::SHADER_SIZE).mul($r);
                 let alignment = $crate::private::AlignmentValue::from_next_power_of_two_size(col_size);
                 let size = alignment.round_up_size(col_size).mul($c);
                 let col_padding = alignment.padding_needed_for(col_size.get());
@@ -145,9 +145,9 @@ macro_rules! impl_matrix_inner {
             };
         }
 
-        impl<$($generics)*> $crate::private::Size for $type
+        impl<$($generics)*> $crate::private::ShaderSize for $type
         where
-            $el_ty: $crate::private::Size
+            $el_ty: $crate::private::ShaderSize
         {}
 
         impl<$($generics)*> $crate::private::WriteInto for $type

--- a/src/types/runtime_sized_array.rs
+++ b/src/types/runtime_sized_array.rs
@@ -1,7 +1,7 @@
 use std::collections::{LinkedList, VecDeque};
 
 use crate::core::{
-    BufferMut, BufferRef, CreateFrom, Metadata, ReadFrom, Reader, RuntimeSizedArray, Size,
+    BufferMut, BufferRef, CreateFrom, Metadata, ReadFrom, Reader, RuntimeSizedArray, ShaderSize,
     WriteInto, Writer,
 };
 use crate::ShaderType;
@@ -36,7 +36,7 @@ impl ShaderType for ArrayLength {
     const METADATA: Metadata<Self::ExtraMetadata> = Metadata::from_alignment_and_size(4, 4);
 }
 
-impl Size for ArrayLength {}
+impl ShaderSize for ArrayLength {}
 
 impl WriteInto for ArrayLength {
     fn write_into<B: BufferMut>(&self, writer: &mut Writer<B>) {
@@ -122,13 +122,13 @@ macro_rules! impl_rts_array_inner {
     (__main, $type:ty, $($generics:tt)*) => {
         impl<$($generics)*> $crate::private::ShaderType for $type
         where
-            T: $crate::private::ShaderType + $crate::private::Size,
+            T: $crate::private::ShaderType + $crate::private::ShaderSize,
             Self: $crate::private::Length,
         {
             type ExtraMetadata = $crate::private::ArrayMetadata;
             const METADATA: $crate::private::Metadata<Self::ExtraMetadata> = {
                 let alignment = T::METADATA.alignment();
-                let el_size = $crate::private::SizeValue::from(T::SIZE);
+                let el_size = $crate::private::SizeValue::from(T::SHADER_SIZE);
 
                 let stride = alignment.round_up_size(el_size);
                 let el_padding = alignment.padding_needed_for(el_size.get());

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -1,6 +1,6 @@
 use crate::core::{
-    BufferMut, BufferRef, CreateFrom, Metadata, ReadFrom, Reader, ShaderType, Size, WriteInto,
-    Writer,
+    BufferMut, BufferRef, CreateFrom, Metadata, ReadFrom, Reader, ShaderSize, ShaderType,
+    WriteInto, Writer,
 };
 use core::num::{NonZeroI32, NonZeroU32, Wrapping};
 use core::sync::atomic::{AtomicI32, AtomicU32};
@@ -12,7 +12,7 @@ macro_rules! impl_basic_traits {
             const METADATA: Metadata<Self::ExtraMetadata> = Metadata::from_alignment_and_size(4, 4);
         }
 
-        impl Size for $type {}
+        impl ShaderSize for $type {}
     };
 }
 

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -109,11 +109,11 @@ macro_rules! impl_vector_inner {
 
         impl<$($generics)*> $crate::private::ShaderType for $type
         where
-            $el_ty: $crate::private::Size,
+            $el_ty: $crate::private::ShaderSize,
         {
             type ExtraMetadata = ();
             const METADATA: $crate::private::Metadata<Self::ExtraMetadata> = {
-                let size = $crate::private::SizeValue::from(<$el_ty as $crate::private::Size>::SIZE).mul($n);
+                let size = $crate::private::SizeValue::from(<$el_ty as $crate::private::ShaderSize>::SHADER_SIZE).mul($n);
                 let alignment = $crate::private::AlignmentValue::from_next_power_of_two_size(size);
 
                 $crate::private::Metadata {
@@ -125,9 +125,9 @@ macro_rules! impl_vector_inner {
             };
         }
 
-        impl<$($generics)*> $crate::private::Size for $type
+        impl<$($generics)*> $crate::private::ShaderSize for $type
         where
-            $el_ty: $crate::private::Size
+            $el_ty: $crate::private::ShaderSize
         {}
 
         impl<$($generics)*> $crate::private::WriteInto for $type

--- a/src/types/wrapper.rs
+++ b/src/types/wrapper.rs
@@ -49,11 +49,11 @@ macro_rules! impl_wrapper_inner {
                 <T as $crate::private::ShaderType>::size(&self$($get_ref)*)
             }
         }
-        impl<$($generics)*> $crate::private::Size for $type
+        impl<$($generics)*> $crate::private::ShaderSize for $type
         where
-            T: $crate::private::Size
+            T: $crate::private::ShaderSize
         {
-            const SIZE: ::core::num::NonZeroU64 = T::SIZE;
+            const SHADER_SIZE: ::core::num::NonZeroU64 = T::SHADER_SIZE;
         }
 
         impl<$($generics)*> $crate::private::RuntimeSizedArray for $type

--- a/tests/hygiene.rs
+++ b/tests/hygiene.rs
@@ -103,7 +103,7 @@ struct Test {
 #[derive(::encase::ShaderType)]
 struct TestGeneric<
     'a,
-    T: 'a + ::encase::ShaderType + ::encase::Size,
+    T: 'a + ::encase::ShaderType + ::encase::ShaderSize,
     const N: ::core::primitive::usize,
 > {
     #[size(90)]


### PR DESCRIPTION
Will merge this before the 0.3 release.

See also https://github.com/bevyengine/bevy/pull/4339#discussion_r876371027