### PR TITLE
Add support for the Rust's unstable allocator-api on Vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ members = ["derive", "derive/impl"]
 [patch.crates-io]
 criterion = { git = "https://github.com/bheisler/criterion.rs", rev = "6929f48e4828360de038f4e9732066d85b9a57c6" }
 
+[features]
+allocator_api = []
+
 [dependencies]
 encase_derive = { version = "=0.3.0", path = "derive" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(docs, feature(doc_cfg))]
 #![cfg_attr(coverage, feature(no_coverage))]
+#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(
     future_incompatible,


### PR DESCRIPTION
This PR adds feature-gated support for rust's new(ish) allocator api on `Vec` (see https://github.com/rust-lang/rust/issues/32838 & https://doc.rust-lang.org/unstable-book/library-features/allocator-api.html).

This enables support for custom allocators, which are often needed in video games & high performance projects, as well as make it possible for libraries supporting the API to use `encase` with user-provided `Vec`s. I haven't added support for `Box<T>` which now can also take a custom allocator, as that feature still sometime causes ICEs.

As for the feature name, I chose `allocator_api`, as that's also the name of Rust's feature (and it's disabled by default).

This takes the form of an additional bound on `Vec`s, which now look like `Vec<T, A> where A: std::alloc::Allocator`.
