### PR TITLE
Properly deal with over-aligned T's in dynamic buffers

### DIFF
--- a/src/core/buffers.rs
+++ b/src/core/buffers.rs
@@ -189,7 +189,9 @@ impl<B: BufferMut> DynamicStorageBuffer<B> {
     where
         T: ShaderType + WriteInto,
     {
-        let offset = self.offset;
+        // Round up the offset to the next multiple of this T's alignment. This allows
+        // T to have a greater alignment than self.alignment.
+        let offset = T::METADATA.alignment.round_up(self.offset as u64) as usize;
 
         let mut writer = Writer::new(value, &mut self.inner, offset)?;
         value.write_into(&mut writer);


### PR DESCRIPTION
This PR allows two different use cases (1 is arguably a bug).

1. It is theoretically possible that the default alignment for https://docs.rs/wgpu/latest/wgpu/struct.Limits.html#structfield.min_storage_buffer_offset_alignment is lower than the most-aligned structure `DVec4`.
2. This lets you use the dynamic storage buffer api to build dynamically defined structures. You can set the designed alignment to 1, then you can use each "element" in the dynamic storage buffer as a member of a different type and it will automatically lay things out correctly.