### PR TITLE
Increase MSRV to 1.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "encase"
 version = "0.4.1"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 
 license = "MIT-0"
 readme = "./README.md"

--- a/src/core/rw.rs
+++ b/src/core/rw.rs
@@ -205,7 +205,7 @@ impl BufferMut for [u8] {
 
     fn write<const N: usize>(&mut self, offset: usize, val: &[u8; N]) {
         use crate::utils::SliceExt;
-        self.copy_from_array(offset, val);
+        *self.array_mut(offset) = *val;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,6 @@ pub mod private {
     pub use super::types::runtime_sized_array::{ArrayLength, Length, Truncate};
     pub use super::types::vector::*;
     pub use super::utils::consume_zsts;
-    pub use super::utils::ArrayExt;
     pub use super::CalculateSizeFor;
     pub use super::ShaderSize;
     pub use super::ShaderType;

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -88,7 +88,7 @@ where
     Self: ShaderType<ExtraMetadata = ArrayMetadata>,
 {
     fn create_from<B: BufferRef>(reader: &mut Reader<B>) -> Self {
-        crate::utils::ArrayExt::from_fn(|_| {
+        core::array::from_fn(|_| {
             let res = CreateFrom::create_from(reader);
             reader.advance(Self::METADATA.el_padding() as usize);
             res

--- a/src/types/matrix.rs
+++ b/src/types/matrix.rs
@@ -188,8 +188,8 @@ macro_rules! impl_matrix_inner {
             $el_ty: $crate::private::MatrixScalar + $crate::private::CreateFrom,
         {
             fn create_from<B: $crate::private::BufferRef>(reader: &mut $crate::private::Reader<B>) -> Self {
-                let columns = $crate::private::ArrayExt::from_fn(|_| {
-                    let col = $crate::private::ArrayExt::from_fn(|_| {
+                let columns = ::core::array::from_fn(|_| {
+                    let col = ::core::array::from_fn(|_| {
                         $crate::private::CreateFrom::create_from(reader)
                     });
                     reader.advance(<Self as $crate::private::ShaderType>::METADATA.col_padding() as ::core::primitive::usize);

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -162,7 +162,7 @@ macro_rules! impl_vector_inner {
             $el_ty: $crate::private::VectorScalar + $crate::private::CreateFrom,
         {
             fn create_from<B: $crate::private::BufferRef>(reader: &mut $crate::private::Reader<B>) -> Self {
-                let elements = $crate::private::ArrayExt::from_fn(|_| {
+                let elements = ::core::array::from_fn(|_| {
                     $crate::private::CreateFrom::create_from(reader)
                 });
 


### PR DESCRIPTION
- use the stabilized `core::array::from_fn`
- remove unnecessary `ArrayExt::copy_from` fn