### PR TITLE
Update `glam` to  `0.23`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ const_panic = { version = "0.2", default-features = false }
 
 mint = { version = "0.5.9", default-features = false, optional = true }
 cgmath = { version = "0.18", default-features = false, optional = true }
-glam = { version = "0.22", features = [ "std" ], default-features = false, optional = true }
+glam = { version = "0.23", features = [ "std" ], default-features = false, optional = true }
 nalgebra = { version = "0.32", default-features = false, optional = true }
 ultraviolet = { version = "0.9", features = [ "int" ], default-features = false, optional = true }
 vek = { version = "0.15", default-features = false, optional = true }


### PR DESCRIPTION
Since the breaking change only affects the `scalar-math` feature, this should cause no issues.