### PR TITLE
migrate to syn 2

### DIFF
--- a/derive/impl/Cargo.toml
+++ b/derive/impl/Cargo.toml
@@ -11,6 +11,6 @@ keywords = ["wgsl", "wgpu"]
 categories = ["rendering"]
 
 [dependencies]
-syn = "1.0.56"
+syn = "2"
 quote = "1"
 proc-macro2 = "1"

--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Ident, Literal, Span, TokenStream};
-use quote::{quote, quote_spanned};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     parse::{Parse, ParseStream},
     parse_quote,
@@ -197,15 +197,15 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
                 align: None,
             };
             for attr in &field.attrs {
-                let span = attr.tokens.span();
-                if attr.path.is_ident("align") {
+                let span = attr.to_token_stream().span();
+                if attr.path().is_ident("align") {
                     let res = attr.parse_args::<AlignmentAttr>();
                     let res = res.map_err(|err| syn::Error::new(span, err));
                     match res {
                         Ok(val) => data.align = Some((val.0, span)),
                         Err(err) => errors.append(err),
                     }
-                } else if attr.path.is_ident("size") {
+                } else if attr.path().is_ident("size") {
                     let res = if i == last_field_index {
                         attr.parse_args::<SizeAttr>().map(|val| match val {
                             SizeAttr::Runtime => {

--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -197,33 +197,41 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
                 align: None,
             };
             for attr in &field.attrs {
-                let span = attr.to_token_stream().span();
-                if attr.path().is_ident("align") {
-                    let res = attr.parse_args::<AlignmentAttr>();
-                    let res = res.map_err(|err| syn::Error::new(span, err));
-                    match res {
-                        Ok(val) => data.align = Some((val.0, span)),
-                        Err(err) => errors.append(err),
-                    }
-                } else if attr.path().is_ident("size") {
-                    let res = if i == last_field_index {
-                        attr.parse_args::<SizeAttr>().map(|val| match val {
-                            SizeAttr::Runtime => {
-                                is_runtime_sized = true;
-                                None
+                match attr.meta.require_list() {
+                    Ok(meta_list) => {
+                        let path = &meta_list.path;
+                        let span = meta_list.tokens.span();
+                        if path.is_ident("align") {
+                            if path.is_ident("align") {
+                                let res = attr.parse_args::<AlignmentAttr>();
+                                let res = res.map_err(|err| syn::Error::new(span, err));
+                                match res {
+                                    Ok(val) => data.align = Some((val.0, span)),
+                                    Err(err) => errors.append(err),
+                                }
+                            } else if path.is_ident("size") {
+                                let res = if i == last_field_index {
+                                    attr.parse_args::<SizeAttr>().map(|val| match val {
+                                        SizeAttr::Runtime => {
+                                            is_runtime_sized = true;
+                                            None
+                                        }
+                                        SizeAttr::Static(size) => Some((size.0, span)),
+                                    })
+                                } else {
+                                    attr.parse_args::<StaticSizeAttr>()
+                                        .map(|val| Some((val.0, span)))
+                                };
+                                let res = res.map_err(|err| syn::Error::new(span, err));
+                                match res {
+                                    Ok(val) => data.size = val,
+                                    Err(err) => errors.append(err),
+                                }
                             }
-                            SizeAttr::Static(size) => Some((size.0, span)),
-                        })
-                    } else {
-                        attr.parse_args::<StaticSizeAttr>()
-                            .map(|val| Some((val.0, span)))
-                    };
-                    let res = res.map_err(|err| syn::Error::new(span, err));
-                    match res {
-                        Ok(val) => data.size = val,
-                        Err(err) => errors.append(err),
+                        }
                     }
-                }
+                    Err(err) => errors.append(err),
+                };
             }
             data
         })

--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Ident, Literal, Span, TokenStream};
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{quote, quote_spanned};
 use syn::{
     parse::{Parse, ParseStream},
     parse_quote,

--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -199,34 +199,29 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
             for attr in &field.attrs {
                 match attr.meta.require_list() {
                     Ok(meta_list) => {
-                        let path = &meta_list.path;
                         let span = meta_list.tokens.span();
-                        if path.is_ident("align") {
-                            if path.is_ident("align") {
-                                let res = attr.parse_args::<AlignmentAttr>();
-                                let res = res.map_err(|err| syn::Error::new(span, err));
-                                match res {
-                                    Ok(val) => data.align = Some((val.0, span)),
-                                    Err(err) => errors.append(err),
-                                }
-                            } else if path.is_ident("size") {
-                                let res = if i == last_field_index {
-                                    attr.parse_args::<SizeAttr>().map(|val| match val {
-                                        SizeAttr::Runtime => {
-                                            is_runtime_sized = true;
-                                            None
-                                        }
-                                        SizeAttr::Static(size) => Some((size.0, span)),
-                                    })
-                                } else {
-                                    attr.parse_args::<StaticSizeAttr>()
-                                        .map(|val| Some((val.0, span)))
-                                };
-                                let res = res.map_err(|err| syn::Error::new(span, err));
-                                match res {
-                                    Ok(val) => data.size = val,
-                                    Err(err) => errors.append(err),
-                                }
+                        if meta_list.path.is_ident("align") {
+                            let res = attr.parse_args::<AlignmentAttr>();
+                            match res {
+                                Ok(val) => data.align = Some((val.0, span)),
+                                Err(err) => errors.append(err),
+                            }
+                        } else if meta_list.path.is_ident("size") {
+                            let res = if i == last_field_index {
+                                attr.parse_args::<SizeAttr>().map(|val| match val {
+                                    SizeAttr::Runtime => {
+                                        is_runtime_sized = true;
+                                        None
+                                    }
+                                    SizeAttr::Static(size) => Some((size.0, span)),
+                                })
+                            } else {
+                                attr.parse_args::<StaticSizeAttr>()
+                                    .map(|val| Some((val.0, span)))
+                            };
+                            match res {
+                                Ok(val) => data.size = val,
+                                Err(err) => errors.append(err),
                             }
                         }
                     }

--- a/tests/compile_fail/invalid_align_attr.stderr
+++ b/tests/compile_fail/invalid_align_attr.stderr
@@ -1,25 +1,23 @@
-error: expected attribute arguments in parentheses: #[align(...)]
- --> tests/compile_fail/invalid_align_attr.rs:5:10
+error: expected attribute arguments in parentheses: `align(...)`
+ --> tests/compile_fail/invalid_align_attr.rs:7:7
   |
-5 | #[derive(ShaderType)]
-  |          ^^^^^^^^^^
-  |
-  = note: this error originates in the derive macro `ShaderType` (in Nightly builds, run with -Z macro-backtrace for more info)
+7 |     #[align]
+  |       ^^^^^
 
 error: expected a power of 2 u32 literal
- --> tests/compile_fail/invalid_align_attr.rs:9:12
+ --> tests/compile_fail/invalid_align_attr.rs:9:13
   |
 9 |     #[align()]
-  |            ^^
+  |             ^
 
 error: expected a power of 2 u32 literal
-  --> tests/compile_fail/invalid_align_attr.rs:11:12
+  --> tests/compile_fail/invalid_align_attr.rs:11:13
    |
 11 |     #[align(invalid)]
-   |            ^^^^^^^^^
+   |             ^^^^^^^
 
 error: expected a power of 2 u32 literal
-  --> tests/compile_fail/invalid_align_attr.rs:13:12
+  --> tests/compile_fail/invalid_align_attr.rs:13:14
    |
 13 |     #[align(3)]
-   |            ^^^
+   |              ^

--- a/tests/compile_fail/invalid_size_attr.stderr
+++ b/tests/compile_fail/invalid_size_attr.stderr
@@ -1,25 +1,23 @@
-error: expected attribute arguments in parentheses: #[size(...)]
- --> tests/compile_fail/invalid_size_attr.rs:5:10
+error: expected attribute arguments in parentheses: `size(...)`
+ --> tests/compile_fail/invalid_size_attr.rs:7:7
   |
-5 | #[derive(ShaderType)]
-  |          ^^^^^^^^^^
-  |
-  = note: this error originates in the derive macro `ShaderType` (in Nightly builds, run with -Z macro-backtrace for more info)
+7 |     #[size]
+  |       ^^^^
 
 error: expected u32 literal
- --> tests/compile_fail/invalid_size_attr.rs:9:11
+ --> tests/compile_fail/invalid_size_attr.rs:9:12
   |
 9 |     #[size()]
-  |           ^^
+  |            ^
 
 error: expected u32 literal
-  --> tests/compile_fail/invalid_size_attr.rs:11:11
+  --> tests/compile_fail/invalid_size_attr.rs:11:12
    |
 11 |     #[size(invalid)]
-   |           ^^^^^^^^^
+   |            ^^^^^^^
 
 error: expected u32 literal or `runtime` identifier
-  --> tests/compile_fail/invalid_size_attr.rs:13:11
+  --> tests/compile_fail/invalid_size_attr.rs:13:14
    |
 13 |     #[size(-1)]
-   |           ^^^^
+   |              ^


### PR DESCRIPTION
Updates `syn` version to `"2"` and updates usage.

Closes https://github.com/teoxoy/encase/issues/36.