### PR TITLE
Inline potentially hot functions more aggressively

### DIFF
--- a/src/core/alignment_value.rs
+++ b/src/core/alignment_value.rs
@@ -15,6 +15,7 @@ impl AlignmentValue {
     }
 
     /// Returns an alignment that is the smallest power of two greater than the passed in `size`
+    #[inline]
     pub const fn from_next_power_of_two_size(size: SizeValue) -> Self {
         match size.get().checked_next_power_of_two() {
             None => panic!("Overflow occured while getting the next power of 2!"),
@@ -25,6 +26,7 @@ impl AlignmentValue {
         }
     }
 
+    #[inline]
     pub const fn get(&self) -> u64 {
         self.0.get()
     }
@@ -46,11 +48,13 @@ impl AlignmentValue {
     }
 
     /// Returns true if `n` is a multiple of this alignment
+    #[inline]
     pub const fn is_aligned(&self, n: u64) -> bool {
         n % self.get() == 0
     }
 
     /// Returns the amount of padding needed so that `n + padding` will be a multiple of this alignment
+    #[inline]
     pub const fn padding_needed_for(&self, n: u64) -> u64 {
         let r = n % self.get();
         if r > 0 {
@@ -61,11 +65,13 @@ impl AlignmentValue {
     }
 
     /// Will round up the given `n` so that the returned value will be a multiple of this alignment
+    #[inline]
     pub const fn round_up(&self, n: u64) -> u64 {
         n + self.padding_needed_for(n)
     }
 
     /// Will round up the given `n` so that the returned value will be a multiple of this alignment
+    #[inline]
     pub const fn round_up_size(&self, n: SizeValue) -> SizeValue {
         SizeValue::new(self.round_up(n.get()))
     }

--- a/src/core/size_value.rs
+++ b/src/core/size_value.rs
@@ -5,6 +5,7 @@ use core::num::NonZeroU64;
 pub struct SizeValue(pub NonZeroU64);
 
 impl SizeValue {
+    #[inline]
     pub const fn new(val: u64) -> Self {
         match val {
             0 => panic!("Size can't be 0!"),
@@ -15,14 +16,17 @@ impl SizeValue {
         }
     }
 
+    #[inline]
     pub const fn from(val: NonZeroU64) -> Self {
         Self(val)
     }
 
+    #[inline]
     pub const fn get(&self) -> u64 {
         self.0.get()
     }
 
+    #[inline]
     pub const fn mul(self, rhs: u64) -> Self {
         match self.get().checked_mul(rhs) {
             None => panic!("Overflow occured while multiplying size values!"),

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -26,12 +26,14 @@ impl Metadata<()> {
 // track #![feature(const_precise_live_drops)] (https://github.com/rust-lang/rust/issues/73255)
 
 impl<E> Metadata<E> {
+    #[inline]
     pub const fn alignment(self) -> AlignmentValue {
         let value = self.alignment;
         core::mem::forget(self);
         value
     }
 
+    #[inline]
     pub const fn uniform_min_alignment(self) -> Option<AlignmentValue> {
         let value = self.has_uniform_min_alignment;
         core::mem::forget(self);
@@ -41,6 +43,7 @@ impl<E> Metadata<E> {
         }
     }
 
+    #[inline]
     pub const fn min_size(self) -> SizeValue {
         let value = self.min_size;
         core::mem::forget(self);
@@ -66,6 +69,7 @@ pub trait ShaderType {
     /// [WGSL structs containing runtime-sized arrays](https://gpuweb.github.io/gpuweb/wgsl/#struct-types)
     /// (non fixed-footprint types)
     /// this will be calculated by assuming the array has one element
+    #[inline]
     fn min_size() -> NonZeroU64 {
         Self::METADATA.min_size().0
     }
@@ -74,6 +78,7 @@ pub trait ShaderType {
     ///
     /// For [WGSL fixed-footprint types](https://gpuweb.github.io/gpuweb/wgsl/#fixed-footprint-types)
     /// it's equivalent to [`Self::min_size`] and [`ShaderSize::SHADER_SIZE`]
+    #[inline]
     fn size(&self) -> NonZeroU64 {
         Self::METADATA.min_size().0
     }
@@ -178,6 +183,7 @@ pub trait ShaderType {
     /// }
     /// Valid::assert_uniform_compat();
     /// ```
+    #[inline]
     fn assert_uniform_compat() {
         Self::UNIFORM_COMPAT_ASSERT()
     }

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -63,6 +63,7 @@ impl<T: WriteInto, const N: usize> WriteInto for [T; N]
 where
     Self: ShaderType<ExtraMetadata = ArrayMetadata>,
 {
+    #[inline]
     fn write_into<B: BufferMut>(&self, writer: &mut Writer<B>) {
         for item in self {
             WriteInto::write_into(item, writer);
@@ -75,6 +76,7 @@ impl<T: ReadFrom, const N: usize> ReadFrom for [T; N]
 where
     Self: ShaderType<ExtraMetadata = ArrayMetadata>,
 {
+    #[inline]
     fn read_from<B: BufferRef>(&mut self, reader: &mut Reader<B>) {
         for elem in self {
             ReadFrom::read_from(elem, reader);
@@ -87,6 +89,7 @@ impl<T: CreateFrom, const N: usize> CreateFrom for [T; N]
 where
     Self: ShaderType<ExtraMetadata = ArrayMetadata>,
 {
+    #[inline]
     fn create_from<B: BufferRef>(reader: &mut Reader<B>) -> Self {
         core::array::from_fn(|_| {
             let res = CreateFrom::create_from(reader);

--- a/src/types/matrix.rs
+++ b/src/types/matrix.rs
@@ -8,6 +8,7 @@ pub struct MatrixMetadata {
 }
 
 impl Metadata<MatrixMetadata> {
+    #[inline]
     pub const fn col_padding(self) -> u64 {
         self.extra.col_padding
     }
@@ -85,6 +86,7 @@ macro_rules! impl_matrix_inner {
             Self: ::core::convert::AsRef<[[$el_ty; $r]; $c]>,
             $el_ty: $crate::private::MatrixScalar,
         {
+            #[inline]
             fn as_ref_parts(&self) -> &[[$el_ty; $r]; $c] {
                 ::core::convert::AsRef::as_ref(self)
             }
@@ -96,6 +98,7 @@ macro_rules! impl_matrix_inner {
             Self: ::core::convert::AsMut<[[$el_ty; $r]; $c]>,
             $el_ty: $crate::private::MatrixScalar,
         {
+            #[inline]
             fn as_mut_parts(&mut self) -> &mut [[$el_ty; $r]; $c] {
                 ::core::convert::AsMut::as_mut(self)
             }
@@ -107,6 +110,7 @@ macro_rules! impl_matrix_inner {
             Self: ::core::convert::From<[[$el_ty; $r]; $c]>,
             $el_ty: $crate::private::MatrixScalar,
         {
+            #[inline]
             fn from_parts(parts: [[$el_ty; $r]; $c]) -> Self {
                 ::core::convert::From::from(parts)
             }
@@ -155,6 +159,7 @@ macro_rules! impl_matrix_inner {
             Self: $crate::private::AsRefMatrixParts<$el_ty, $c, $r> + $crate::private::ShaderType<ExtraMetadata = $crate::private::MatrixMetadata>,
             $el_ty: $crate::private::MatrixScalar + $crate::private::WriteInto,
         {
+            #[inline]
             fn write_into<B: $crate::private::BufferMut>(&self, writer: &mut $crate::private::Writer<B>) {
                 let columns = $crate::private::AsRefMatrixParts::<$el_ty, $c, $r>::as_ref_parts(self);
                 for col in columns {
@@ -171,6 +176,7 @@ macro_rules! impl_matrix_inner {
             Self: $crate::private::AsMutMatrixParts<$el_ty, $c, $r> + $crate::private::ShaderType<ExtraMetadata = $crate::private::MatrixMetadata>,
             $el_ty: $crate::private::MatrixScalar + $crate::private::ReadFrom,
         {
+            #[inline]
             fn read_from<B: $crate::private::BufferRef>(&mut self, reader: &mut $crate::private::Reader<B>) {
                 let columns = $crate::private::AsMutMatrixParts::<$el_ty, $c, $r>::as_mut_parts(self);
                 for col in columns {
@@ -187,6 +193,7 @@ macro_rules! impl_matrix_inner {
             Self: $crate::private::FromMatrixParts<$el_ty, $c, $r> + $crate::private::ShaderType<ExtraMetadata = $crate::private::MatrixMetadata>,
             $el_ty: $crate::private::MatrixScalar + $crate::private::CreateFrom,
         {
+            #[inline]
             fn create_from<B: $crate::private::BufferRef>(reader: &mut $crate::private::Reader<B>) -> Self {
                 let columns = ::core::array::from_fn(|_| {
                     let col = ::core::array::from_fn(|_| {

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -21,18 +21,21 @@ macro_rules! impl_traits {
         impl_basic_traits!($type);
 
         impl WriteInto for $type {
+            #[inline]
             fn write_into<B: BufferMut>(&self, writer: &mut Writer<B>) {
                 writer.write(&<$type>::to_le_bytes(*self));
             }
         }
 
         impl ReadFrom for $type {
+            #[inline]
             fn read_from<B: BufferRef>(&mut self, reader: &mut Reader<B>) {
                 *self = <$type>::from_le_bytes(*reader.read());
             }
         }
 
         impl CreateFrom for $type {
+            #[inline]
             fn create_from<B: BufferRef>(reader: &mut Reader<B>) -> Self {
                 <$type>::from_le_bytes(*reader.read())
             }
@@ -49,6 +52,7 @@ macro_rules! impl_traits_for_non_zero_option {
         impl_basic_traits!(Option<$type>);
 
         impl WriteInto for Option<$type> {
+            #[inline]
             fn write_into<B: BufferMut>(&self, writer: &mut Writer<B>) {
                 let value = self.map(|num| num.get()).unwrap_or(0);
                 WriteInto::write_into(&value, writer);
@@ -56,12 +60,14 @@ macro_rules! impl_traits_for_non_zero_option {
         }
 
         impl ReadFrom for Option<$type> {
+            #[inline]
             fn read_from<B: BufferRef>(&mut self, reader: &mut Reader<B>) {
                 *self = <$type>::new(CreateFrom::create_from(reader));
             }
         }
 
         impl CreateFrom for Option<$type> {
+            #[inline]
             fn create_from<B: BufferRef>(reader: &mut Reader<B>) -> Self {
                 <$type>::new(CreateFrom::create_from(reader))
             }
@@ -77,18 +83,21 @@ macro_rules! impl_traits_for_wrapping {
         impl_basic_traits!($type);
 
         impl WriteInto for $type {
+            #[inline]
             fn write_into<B: BufferMut>(&self, writer: &mut Writer<B>) {
                 WriteInto::write_into(&self.0, writer);
             }
         }
 
         impl ReadFrom for $type {
+            #[inline]
             fn read_from<B: BufferRef>(&mut self, reader: &mut Reader<B>) {
                 ReadFrom::read_from(&mut self.0, reader);
             }
         }
 
         impl CreateFrom for $type {
+            #[inline]
             fn create_from<B: BufferRef>(reader: &mut Reader<B>) -> Self {
                 Wrapping(CreateFrom::create_from(reader))
             }
@@ -104,6 +113,7 @@ macro_rules! impl_traits_for_atomic {
         impl_basic_traits!($type);
 
         impl WriteInto for $type {
+            #[inline]
             fn write_into<B: BufferMut>(&self, writer: &mut Writer<B>) {
                 let value = self.load(std::sync::atomic::Ordering::Relaxed);
                 WriteInto::write_into(&value, writer);
@@ -111,12 +121,14 @@ macro_rules! impl_traits_for_atomic {
         }
 
         impl ReadFrom for $type {
+            #[inline]
             fn read_from<B: BufferRef>(&mut self, reader: &mut Reader<B>) {
                 ReadFrom::read_from(self.get_mut(), reader);
             }
         }
 
         impl CreateFrom for $type {
+            #[inline]
             fn create_from<B: BufferRef>(reader: &mut Reader<B>) -> Self {
                 <$type>::new(CreateFrom::create_from(reader))
             }

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -73,6 +73,7 @@ macro_rules! impl_vector_inner {
             Self: ::core::convert::AsRef<[$el_ty; $n]>,
             $el_ty: $crate::private::VectorScalar,
         {
+            #[inline]
             fn as_ref_parts(&self) -> &[$el_ty; $n] {
                 ::core::convert::AsRef::as_ref(self)
             }
@@ -84,6 +85,7 @@ macro_rules! impl_vector_inner {
             Self: ::core::convert::AsMut<[$el_ty; $n]>,
             $el_ty: $crate::private::VectorScalar,
         {
+            #[inline]
             fn as_mut_parts(&mut self) -> &mut [$el_ty; $n] {
                 ::core::convert::AsMut::as_mut(self)
             }
@@ -95,6 +97,7 @@ macro_rules! impl_vector_inner {
             Self: ::core::convert::From<[$el_ty; $n]>,
             $el_ty: $crate::private::VectorScalar,
         {
+            #[inline]
             fn from_parts(parts: [$el_ty; $n]) -> Self {
                 ::core::convert::From::from(parts)
             }
@@ -135,6 +138,7 @@ macro_rules! impl_vector_inner {
             Self: $crate::private::AsRefVectorParts<$el_ty, $n>,
             $el_ty: $crate::private::VectorScalar + $crate::private::WriteInto,
         {
+            #[inline]
             fn write_into<B: $crate::private::BufferMut>(&self, writer: &mut $crate::private::Writer<B>) {
                 let elements = $crate::private::AsRefVectorParts::<$el_ty, $n>::as_ref_parts(self);
                 for el in elements {
@@ -148,6 +152,7 @@ macro_rules! impl_vector_inner {
             Self: $crate::private::AsMutVectorParts<$el_ty, $n>,
             $el_ty: $crate::private::VectorScalar + $crate::private::ReadFrom,
         {
+            #[inline]
             fn read_from<B: $crate::private::BufferRef>(&mut self, reader: &mut $crate::private::Reader<B>) {
                 let elements = $crate::private::AsMutVectorParts::<$el_ty, $n>::as_mut_parts(self);
                 for el in elements {
@@ -161,6 +166,7 @@ macro_rules! impl_vector_inner {
             Self: $crate::private::FromVectorParts<$el_ty, $n>,
             $el_ty: $crate::private::VectorScalar + $crate::private::CreateFrom,
         {
+            #[inline]
             fn create_from<B: $crate::private::BufferRef>(reader: &mut $crate::private::Reader<B>) -> Self {
                 let elements = ::core::array::from_fn(|_| {
                     $crate::private::CreateFrom::create_from(reader)

--- a/src/types/wrapper.rs
+++ b/src/types/wrapper.rs
@@ -45,6 +45,7 @@ macro_rules! impl_wrapper_inner {
 
             const UNIFORM_COMPAT_ASSERT: fn() = T::UNIFORM_COMPAT_ASSERT;
 
+            #[inline]
             fn size(&self) -> ::core::num::NonZeroU64 {
                 <T as $crate::private::ShaderType>::size(&self$($get_ref)*)
             }
@@ -60,6 +61,7 @@ macro_rules! impl_wrapper_inner {
         where
             T: $crate::private::RuntimeSizedArray
         {
+            #[inline]
             fn len(&self) -> usize {
                 <T as $crate::private::RuntimeSizedArray>::len(&self$($get_ref)*)
             }
@@ -69,6 +71,7 @@ macro_rules! impl_wrapper_inner {
         where
             T: $crate::private::CalculateSizeFor
         {
+            #[inline]
             fn calculate_size_for(nr_of_el: u64) -> ::core::num::NonZeroU64 {
                 <T as $crate::private::CalculateSizeFor>::calculate_size_for(nr_of_el)
             }
@@ -78,6 +81,7 @@ macro_rules! impl_wrapper_inner {
         where
             T: $crate::private::WriteInto
         {
+            #[inline]
             fn write_into<B: $crate::private::BufferMut>(&self, writer: &mut $crate::private::Writer<B>) {
                 <T as $crate::private::WriteInto>::write_into(&self$($get_ref)*, writer)
             }
@@ -88,6 +92,7 @@ macro_rules! impl_wrapper_inner {
         where
             T: $crate::private::ReadFrom
         {
+            #[inline]
             fn read_from<B: $crate::private::BufferRef>(&mut self, reader: &mut $crate::private::Reader<B>) {
                 <T as $crate::private::ReadFrom>::read_from(self$($get_mut)*, reader)
             }
@@ -98,6 +103,7 @@ macro_rules! impl_wrapper_inner {
         where
             T: $crate::private::CreateFrom
         {
+            #[inline]
             fn create_from<B: $crate::private::BufferRef>(reader: &mut $crate::private::Reader<B>) -> Self {
                 <$type>::$($from)*(<T as $crate::private::CreateFrom>::create_from(reader))
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -112,6 +112,7 @@ impl<T> SliceExt<T> for [T] {
     // from rust core lib https://github.com/rust-lang/rust/blob/11d96b59307b1702fffe871bfc2d0145d070881e/library/core/src/slice/mod.rs#L1794
     // track #![feature(split_array)] (https://github.com/rust-lang/rust/issues/90091)
 
+    #[inline]
     fn array<const N: usize>(&self, offset: usize) -> &[T; N] {
         let src = &self[offset..offset + N];
 
@@ -123,6 +124,7 @@ impl<T> SliceExt<T> for [T] {
     // from rust core lib https://github.com/rust-lang/rust/blob/11d96b59307b1702fffe871bfc2d0145d070881e/library/core/src/slice/mod.rs#L1827
     // track #![feature(split_array)] (https://github.com/rust-lang/rust/issues/90091)
 
+    #[inline]
     fn array_mut<const N: usize>(&mut self, offset: usize) -> &mut [T; N] {
         let src = &mut self[offset..offset + N];
 


### PR DESCRIPTION
The functions when reading and writing using encase's wrappers can be very hot. #38 shows that these functions are not being inlined as aggressively. This PR attempts to coax the compiler doing so. Resolves #38.

Full benchmark results:
<details>

```
Gnuplot not found, using plotters backend
Benchmarking Troughput/16KiB_write
Benchmarking Troughput/16KiB_write: Warming up for 3.0000 s
Benchmarking Troughput/16KiB_write: Collecting 100 samples in estimated 5.0075 s (1.9M iterations)
Benchmarking Troughput/16KiB_write: Analyzing
Troughput/16KiB_write   time:   [1.5729 µs 1.5746 µs 1.5763 µs]
                        thrpt:  [9.6799 GiB/s 9.6903 GiB/s 9.7013 GiB/s]
                 change:
                        time:   [-8.0639% -7.8170% -7.5969%] (p = 0.00 < 0.05)
                        thrpt:  [+8.2215% +8.4799% +8.7713%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low severe
  3 (3.00%) high mild
Benchmarking Troughput/16KiB_read
Benchmarking Troughput/16KiB_read: Warming up for 3.0000 s
Benchmarking Troughput/16KiB_read: Collecting 100 samples in estimated 5.0047 s (2.3M iterations)
Benchmarking Troughput/16KiB_read: Analyzing
Troughput/16KiB_read    time:   [1.0712 µs 1.0730 µs 1.0748 µs]
                        thrpt:  [14.197 GiB/s 14.221 GiB/s 14.244 GiB/s]
                 change:
                        time:   [-11.805% -11.044% -10.376%] (p = 0.00 < 0.05)
                        thrpt:  [+11.578% +12.415% +13.386%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) low mild
Benchmarking Troughput/16KiB_create
Benchmarking Troughput/16KiB_create: Warming up for 3.0000 s
Benchmarking Troughput/16KiB_create: Collecting 100 samples in estimated 5.0085 s (1.5M iterations)
Benchmarking Troughput/16KiB_create: Analyzing
Troughput/16KiB_create  time:   [2.4438 µs 2.4495 µs 2.4545 µs]
                        thrpt:  [6.2166 GiB/s 6.2293 GiB/s 6.2439 GiB/s]
                 change:
                        time:   [-63.717% -63.466% -63.239%] (p = 0.00 < 0.05)
                        thrpt:  [+172.03% +173.72% +175.61%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low severe
  4 (4.00%) low mild
Benchmarking Troughput/16KiB_manual
Benchmarking Troughput/16KiB_manual: Warming up for 3.0000 s
Benchmarking Troughput/16KiB_manual: Collecting 100 samples in estimated 5.0078 s (3.0M iterations)
Benchmarking Troughput/16KiB_manual: Analyzing
Troughput/16KiB_manual  time:   [356.64 ns 357.51 ns 358.17 ns]
                        thrpt:  [42.602 GiB/s 42.681 GiB/s 42.785 GiB/s]
                 change:
                        time:   [-2.8350% -1.1837% +0.5988%] (p = 0.19 > 0.05)
                        thrpt:  [-0.5953% +1.1979% +2.9177%]
                        No change in performance detected.
Benchmarking Troughput/16KiB_stdlib
Benchmarking Troughput/16KiB_stdlib: Warming up for 3.0000 s
Benchmarking Troughput/16KiB_stdlib: Collecting 100 samples in estimated 5.0018 s (3.1M iterations)
Benchmarking Troughput/16KiB_stdlib: Analyzing
Troughput/16KiB_stdlib  time:   [379.93 ns 381.21 ns 382.13 ns]
                        thrpt:  [39.931 GiB/s 40.028 GiB/s 40.163 GiB/s]
                 change:
                        time:   [-2.7601% -0.1978% +2.5277%] (p = 0.89 > 0.05)
                        thrpt:  [-2.4654% +0.1982% +2.8384%]
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
Benchmarking Troughput/128KiB_write
Benchmarking Troughput/128KiB_write: Warming up for 3.0000 s
Benchmarking Troughput/128KiB_write: Collecting 100 samples in estimated 5.0964 s (252k iterations)
Benchmarking Troughput/128KiB_write: Analyzing
Troughput/128KiB_write  time:   [12.469 µs 12.475 µs 12.482 µs]
                        thrpt:  [9.7800 GiB/s 9.7854 GiB/s 9.7902 GiB/s]
                 change:
                        time:   [-8.5845% -8.4567% -8.3377%] (p = 0.00 < 0.05)
                        thrpt:  [+9.0960% +9.2379% +9.3906%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
Benchmarking Troughput/128KiB_read
Benchmarking Troughput/128KiB_read: Warming up for 3.0000 s
Benchmarking Troughput/128KiB_read: Collecting 100 samples in estimated 5.0326 s (323k iterations)
Benchmarking Troughput/128KiB_read: Analyzing
Troughput/128KiB_read   time:   [8.4088 µs 8.4427 µs 8.4746 µs]
                        thrpt:  [14.404 GiB/s 14.459 GiB/s 14.517 GiB/s]
                 change:
                        time:   [-14.693% -12.591% -10.795%] (p = 0.00 < 0.05)
                        thrpt:  [+12.102% +14.404% +17.223%]
                        Performance has improved.
Benchmarking Troughput/128KiB_create
Benchmarking Troughput/128KiB_create: Warming up for 3.0000 s
Benchmarking Troughput/128KiB_create: Collecting 100 samples in estimated 5.0483 s (207k iterations)
Benchmarking Troughput/128KiB_create: Analyzing
Troughput/128KiB_create time:   [16.998 µs 17.016 µs 17.034 µs]
                        thrpt:  [7.1665 GiB/s 7.1740 GiB/s 7.1815 GiB/s]
                 change:
                        time:   [-67.741% -67.671% -67.614%] (p = 0.00 < 0.05)
                        thrpt:  [+208.77% +209.32% +209.99%]
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  12 (12.00%) low mild
  4 (4.00%) high mild
Benchmarking Troughput/128KiB_manual
Benchmarking Troughput/128KiB_manual: Warming up for 3.0000 s
Benchmarking Troughput/128KiB_manual: Collecting 100 samples in estimated 5.0282 s (439k iterations)
Benchmarking Troughput/128KiB_manual: Analyzing
Troughput/128KiB_manual time:   [2.6861 µs 2.6882 µs 2.6903 µs]
                        thrpt:  [45.374 GiB/s 45.410 GiB/s 45.446 GiB/s]
                 change:
                        time:   [-0.9956% +0.0743% +1.1614%] (p = 0.89 > 0.05)
                        thrpt:  [-1.1481% -0.0743% +1.0056%]
                        No change in performance detected.
Found 22 outliers among 100 measurements (22.00%)
  9 (9.00%) low severe
  13 (13.00%) low mild
Benchmarking Troughput/128KiB_stdlib
Benchmarking Troughput/128KiB_stdlib: Warming up for 3.0000 s
Benchmarking Troughput/128KiB_stdlib: Collecting 100 samples in estimated 5.0218 s (303k iterations)
Benchmarking Troughput/128KiB_stdlib: Analyzing
Troughput/128KiB_stdlib time:   [2.9594 µs 2.9727 µs 2.9827 µs]
                        thrpt:  [40.926 GiB/s 41.064 GiB/s 41.248 GiB/s]
                 change:
                        time:   [-3.8721% -1.7726% +0.2982%] (p = 0.10 > 0.05)
                        thrpt:  [-0.2973% +1.8046% +4.0281%]
                        No change in performance detected.
Benchmarking Troughput/1MiB_write
Benchmarking Troughput/1MiB_write: Warming up for 3.0000 s
Benchmarking Troughput/1MiB_write: Collecting 100 samples in estimated 5.2833 s (30k iterations)
Benchmarking Troughput/1MiB_write: Analyzing
Troughput/1MiB_write    time:   [116.57 µs 116.63 µs 116.70 µs]
                        thrpt:  [8.3683 GiB/s 8.3731 GiB/s 8.3774 GiB/s]
                 change:
                        time:   [-12.534% -12.325% -12.157%] (p = 0.00 < 0.05)
                        thrpt:  [+13.840% +14.058% +14.330%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
Benchmarking Troughput/1MiB_read
Benchmarking Troughput/1MiB_read: Warming up for 3.0000 s
Benchmarking Troughput/1MiB_read: Collecting 100 samples in estimated 5.2757 s (35k iterations)
Benchmarking Troughput/1MiB_read: Analyzing
Troughput/1MiB_read     time:   [94.258 µs 94.435 µs 94.643 µs]
                        thrpt:  [10.318 GiB/s 10.341 GiB/s 10.360 GiB/s]
                 change:
                        time:   [-6.8999% -6.5813% -6.2845%] (p = 0.00 < 0.05)
                        thrpt:  [+6.7059% +7.0450% +7.4113%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe
Benchmarking Troughput/1MiB_create
Benchmarking Troughput/1MiB_create: Warming up for 3.0000 s
Benchmarking Troughput/1MiB_create: Collecting 100 samples in estimated 5.1894 s (25k iterations)
Benchmarking Troughput/1MiB_create: Analyzing
Troughput/1MiB_create   time:   [154.30 µs 154.51 µs 154.76 µs]
                        thrpt:  [6.3103 GiB/s 6.3202 GiB/s 6.3291 GiB/s]
                 change:
                        time:   [-64.810% -64.757% -64.706%] (p = 0.00 < 0.05)
                        thrpt:  [+183.33% +183.74% +184.17%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
Benchmarking Troughput/1MiB_manual
Benchmarking Troughput/1MiB_manual: Warming up for 3.0000 s
Benchmarking Troughput/1MiB_manual: Collecting 100 samples in estimated 5.4942 s (40k iterations)
Benchmarking Troughput/1MiB_manual: Analyzing
Troughput/1MiB_manual   time:   [55.898 µs 56.160 µs 56.522 µs]
                        thrpt:  [17.278 GiB/s 17.389 GiB/s 17.470 GiB/s]
                 change:
                        time:   [-4.0751% -3.1067% -2.2785%] (p = 0.00 < 0.05)
                        thrpt:  [+2.3316% +3.2063% +4.2482%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking Troughput/1MiB_stdlib
Benchmarking Troughput/1MiB_stdlib: Warming up for 3.0000 s
Benchmarking Troughput/1MiB_stdlib: Collecting 100 samples in estimated 5.3567 s (35k iterations)
Benchmarking Troughput/1MiB_stdlib: Analyzing
Troughput/1MiB_stdlib   time:   [78.908 µs 79.002 µs 79.100 µs]
                        thrpt:  [12.346 GiB/s 12.361 GiB/s 12.376 GiB/s]
                 change:
                        time:   [+8.2706% +8.7065% +9.0880%] (p = 0.00 < 0.05)
                        thrpt:  [-8.3309% -8.0092% -7.6388%]
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) low severe
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
Benchmarking Troughput/16MiB_write
Benchmarking Troughput/16MiB_write: Warming up for 3.0000 s
Benchmarking Troughput/16MiB_write: Collecting 100 samples in estimated 5.1046 s (1700 iterations)
Benchmarking Troughput/16MiB_write: Analyzing
Troughput/16MiB_write   time:   [1.9566 ms 1.9629 ms 1.9704 ms]
                        thrpt:  [7.9299 GiB/s 7.9602 GiB/s 7.9857 GiB/s]
                 change:
                        time:   [-9.5856% -9.1602% -8.7316%] (p = 0.00 < 0.05)
                        thrpt:  [+9.5670% +10.084% +10.602%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
Benchmarking Troughput/16MiB_read
Benchmarking Troughput/16MiB_read: Warming up for 3.0000 s
Benchmarking Troughput/16MiB_read: Collecting 100 samples in estimated 5.0517 s (2000 iterations)
Benchmarking Troughput/16MiB_read: Analyzing
Troughput/16MiB_read    time:   [1.5998 ms 1.6033 ms 1.6074 ms]
                        thrpt:  [9.7208 GiB/s 9.7455 GiB/s 9.7666 GiB/s]
                 change:
                        time:   [-5.7922% -4.1732% -3.0456%] (p = 0.00 < 0.05)
                        thrpt:  [+3.1412% +4.3549% +6.1484%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
Benchmarking Troughput/16MiB_create
Benchmarking Troughput/16MiB_create: Warming up for 3.0000 s
Benchmarking Troughput/16MiB_create: Collecting 100 samples in estimated 5.1876 s (1500 iterations)
Benchmarking Troughput/16MiB_create: Analyzing
Troughput/16MiB_create  time:   [2.5976 ms 2.6039 ms 2.6114 ms]
                        thrpt:  [5.9833 GiB/s 6.0006 GiB/s 6.0151 GiB/s]
                 change:
                        time:   [-63.189% -63.099% -62.987%] (p = 0.00 < 0.05)
                        thrpt:  [+170.17% +170.99% +171.66%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
Benchmarking Troughput/16MiB_manual
Benchmarking Troughput/16MiB_manual: Warming up for 3.0000 s
Benchmarking Troughput/16MiB_manual: Collecting 100 samples in estimated 5.0462 s (2100 iterations)
Benchmarking Troughput/16MiB_manual: Analyzing
Troughput/16MiB_manual  time:   [1.1353 ms 1.1425 ms 1.1508 ms]
                        thrpt:  [13.577 GiB/s 13.677 GiB/s 13.763 GiB/s]
                 change:
                        time:   [+15.028% +16.322% +17.589%] (p = 0.00 < 0.05)
                        thrpt:  [-14.958% -14.032% -13.065%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking Troughput/16MiB_stdlib
Benchmarking Troughput/16MiB_stdlib: Warming up for 3.0000 s
Benchmarking Troughput/16MiB_stdlib: Collecting 100 samples in estimated 5.0448 s (1900 iterations)
Benchmarking Troughput/16MiB_stdlib: Analyzing
Troughput/16MiB_stdlib  time:   [1.3901 ms 1.3965 ms 1.4041 ms]
                        thrpt:  [11.128 GiB/s 11.189 GiB/s 11.240 GiB/s]
                 change:
                        time:   [-2.3783% -1.1699% +0.0554%] (p = 0.06 > 0.05)
                        thrpt:  [-0.0554% +1.1838% +2.4363%]
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe
Benchmarking Troughput/512MiB_write
Benchmarking Troughput/512MiB_write: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 19.1s, or reduce sample count to 20.
Benchmarking Troughput/512MiB_write: Collecting 100 samples in estimated 19.137 s (100 iterations)
Benchmarking Troughput/512MiB_write: Analyzing
Troughput/512MiB_write  time:   [105.70 ms 106.25 ms 107.17 ms]
                        thrpt:  [4.6656 GiB/s 4.7059 GiB/s 4.7305 GiB/s]
                 change:
                        time:   [-3.4867% -2.8708% -1.9544%] (p = 0.00 < 0.05)
                        thrpt:  [+1.9933% +2.9557% +3.6127%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking Troughput/512MiB_read
Benchmarking Troughput/512MiB_read: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 15.9s, or reduce sample count to 30.
Benchmarking Troughput/512MiB_read: Collecting 100 samples in estimated 15.917 s (100 iterations)
Benchmarking Troughput/512MiB_read: Analyzing
Troughput/512MiB_read   time:   [74.217 ms 74.329 ms 74.451 ms]
                        thrpt:  [6.7158 GiB/s 6.7268 GiB/s 6.7370 GiB/s]
                 change:
                        time:   [-6.1588% -5.7873% -5.4313%] (p = 0.00 < 0.05)
                        thrpt:  [+5.7432% +6.1428% +6.5630%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Benchmarking Troughput/512MiB_create
Benchmarking Troughput/512MiB_create: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 19.0s, or reduce sample count to 20.
Benchmarking Troughput/512MiB_create: Collecting 100 samples in estimated 18.960 s (100 iterations)
Benchmarking Troughput/512MiB_create: Analyzing
Troughput/512MiB_create time:   [100.19 ms 102.03 ms 104.11 ms]
                        thrpt:  [4.8028 GiB/s 4.9007 GiB/s 4.9906 GiB/s]
                 change:
                        time:   [-60.347% -59.363% -58.254%] (p = 0.00 < 0.05)
                        thrpt:  [+139.54% +146.08% +152.19%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) high mild
  10 (10.00%) high severe
Benchmarking Troughput/512MiB_manual
Benchmarking Troughput/512MiB_manual: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 16.0s, or reduce sample count to 30.
Benchmarking Troughput/512MiB_manual: Collecting 100 samples in estimated 15.993 s (100 iterations)
Benchmarking Troughput/512MiB_manual: Analyzing
Troughput/512MiB_manual time:   [44.600 ms 44.820 ms 45.094 ms]
                        thrpt:  [11.088 GiB/s 11.156 GiB/s 11.211 GiB/s]
                 change:
                        time:   [-3.9187% -2.6812% -1.4457%] (p = 0.00 < 0.05)
                        thrpt:  [+1.4669% +2.7551% +4.0785%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe
Benchmarking Troughput/512MiB_stdlib
Benchmarking Troughput/512MiB_stdlib: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 14.1s, or reduce sample count to 30.
Benchmarking Troughput/512MiB_stdlib: Collecting 100 samples in estimated 14.084 s (100 iterations)
Benchmarking Troughput/512MiB_stdlib: Analyzing
Troughput/512MiB_stdlib time:   [28.370 ms 28.449 ms 28.539 ms]
                        thrpt:  [17.520 GiB/s 17.575 GiB/s 17.624 GiB/s]
                 change:
                        time:   [-4.1694% -3.0445% -2.0873%] (p = 0.00 < 0.05)
                        thrpt:  [+2.1318% +3.1401% +4.3509%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe
```
</details>

It does seem like the `create` cases are over two times faster.