### PR TITLE
accept doc comments when deriving `ShaderType`

### DIFF
--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -197,6 +197,9 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
                 align: None,
             };
             for attr in &field.attrs {
+                if !(attr.meta.path().is_ident("size") || attr.meta.path().is_ident("align")) {
+                    continue;
+                }
                 match attr.meta.require_list() {
                     Ok(meta_list) => {
                         let span = meta_list.tokens.span();

--- a/tests/pass/attributes.rs
+++ b/tests/pass/attributes.rs
@@ -21,6 +21,6 @@ struct TestRtArray {
 
 #[derive(ShaderType)]
 struct TestDocComment {
-    /// This is an unisgned integer
+    /// This is an unsigned integer
     a: u32,
 }

--- a/tests/pass/attributes.rs
+++ b/tests/pass/attributes.rs
@@ -18,3 +18,9 @@ struct TestRtArray {
     #[size(runtime)]
     b: Vec<u32>,
 }
+
+#[derive(ShaderType)]
+struct TestDocComment {
+    /// This is an unisgned integer
+    a: u32,
+}


### PR DESCRIPTION
Since the migration to `syn` 2 (#35), doc comments are not accepted:

```
test tests/pass/attributes.rs [should pass] ... error
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: expected `(`
  --> tests/pass/attributes.rs:24:5
   |
24 |     /// This is an unisgned integer
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
```

This PR stops checking attributes that are not owned by this crate