### PR TITLE
Add Single Member Construction Functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ imbl = { version = "3", default-features = false, optional = true }
 static-rc = { version = "0.6", features = ["alloc"], default-features = false, optional = true }
 
 [dev-dependencies]
+bytemuck = { version = "1", default-features = false }
 criterion = { version = "0.4", features = ["cargo_bench_support", "html_reports"], default-features = false }
 rand = { version = "0.8", features = ["std_rng"], default-features = false }
 mimalloc = { version = "0.1", default-features = false }

--- a/src/core/buffers.rs
+++ b/src/core/buffers.rs
@@ -432,7 +432,7 @@ impl<B: BufferRef> DynamicUniformBuffer<B> {
         T::assert_uniform_compat();
         self.inner.read(value)
     }
-    
+
     /// Reads a single member from the buffer. The value is read at the
     /// next available offset after the buffer's current offset, which is aligned the
     /// alignment of `T`.
@@ -449,7 +449,7 @@ impl<B: BufferRef> DynamicUniformBuffer<B> {
         T::assert_uniform_compat();
         self.inner.read_single_member(value)
     }
-    
+
     /// Reads a "struct break" from the buffer. This takes the buffer offset and aligns it
     /// to the required dynamic binding alignment (defaults to 256).
     ///

--- a/tests/single_member.rs
+++ b/tests/single_member.rs
@@ -1,0 +1,54 @@
+use encase::ShaderType;
+
+#[derive(ShaderType)]
+struct Test {
+    a: u32,
+}
+
+#[test]
+fn single_member_uniform() {
+    let mut buffer = encase::DynamicUniformBuffer::new(Vec::<u8>::new());
+
+    assert_eq!(buffer.write_struct_member(&1_u32).unwrap(), 0);
+    assert_eq!(
+        buffer.write_struct_member(&glam::UVec2::new(2, 3)).unwrap(),
+        8
+    );
+    assert_eq!(buffer.write_struct_member(&4_u32).unwrap(), 16);
+    assert_eq!(
+        buffer
+            .write_struct_member(&glam::UVec3::new(5, 6, 7))
+            .unwrap(),
+        32
+    );
+    assert_eq!(buffer.write_struct_member(&[8, 9]).unwrap(), 48);
+    assert_eq!(buffer.write_struct_member(&Test { a: 10 }).unwrap(), 64);
+
+    let cast: &[u32] = bytemuck::cast_slice(buffer.as_ref());
+
+    assert_eq!(cast, &[1, 0, 2, 3, 4, 0, 0, 0, 5, 6, 7, 0, 8, 9, 0, 0, 10]);
+}
+
+#[test]
+fn single_member_storage() {
+    let mut buffer = encase::DynamicStorageBuffer::new(Vec::<u8>::new());
+
+    assert_eq!(buffer.write_struct_member(&1_u32).unwrap(), 0);
+    assert_eq!(
+        buffer.write_struct_member(&glam::UVec2::new(2, 3)).unwrap(),
+        8
+    );
+    assert_eq!(buffer.write_struct_member(&4_u32).unwrap(), 16);
+    assert_eq!(
+        buffer
+            .write_struct_member(&glam::UVec3::new(5, 6, 7))
+            .unwrap(),
+        32
+    );
+    assert_eq!(buffer.write_struct_member(&[8, 9]).unwrap(), 44);
+    assert_eq!(buffer.write_struct_member(&Test { a: 10 }).unwrap(), 52);
+
+    let cast: &[u32] = bytemuck::cast_slice(buffer.as_ref());
+
+    assert_eq!(cast, &[1, 0, 2, 3, 4, 0, 0, 0, 5, 6, 7, 8, 9, 10]);
+}


### PR DESCRIPTION
This isn't totally finished, wanted to get your opinion of the API change before I went and wrote more docs and tests.

The main change is that I switched the alignment operations from after the write to before the write. This is not an observable change with existing apis, but makes this API possible.