### PR TITLE
Fix min syn version

### DIFF
--- a/derive/impl/Cargo.toml
+++ b/derive/impl/Cargo.toml
@@ -11,6 +11,6 @@ keywords = ["wgsl", "wgpu"]
 categories = ["rendering"]
 
 [dependencies]
-syn = "2"
+syn = "2.0.1"
 quote = "1"
 proc-macro2 = "1"


### PR DESCRIPTION
Not sure how this slipped through in https://github.com/teoxoy/encase/pull/35. 
Looking at the CI log, somehow `v2.0.15` got used instead of `v2.0.0`.