### PR TITLE
Remove offline param

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,6 @@ jobs:
           sudo apt-get update -y -qq
           sudo add-apt-repository ppa:oibaf/graphics-drivers -y
           sudo apt-get update
-          sudo apt install -y libxcb-xfixes0-dev mesa-vulkan-drivers
+          sudo apt install -y mesa-vulkan-drivers vulkan-validationlayers
 
       - run: cargo llvm-cov nextest --workspace --features mint,glam --fail-under-lines 80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: rustup toolchain install $NIGHTLY --no-self-update --profile=minimal
 
       # -Z avoid-dev-deps doesn't work
-      - run: cargo +$NIGHTLY hack generate-lockfile --remove-dev-deps -Z minimal-versions --offline
+      - run: cargo +$NIGHTLY hack generate-lockfile --remove-dev-deps -Z minimal-versions
 
       - run: cargo +$MSRV check --workspace --all-features
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,6 @@ jobs:
 
       - name: Install llvmpipe and lavapipe
         run: |
-          sudo apt-get update -y -qq
-          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
           sudo apt-get update
           sudo apt install -y mesa-vulkan-drivers vulkan-validationlayers
 

--- a/src/types/runtime_sized_array.rs
+++ b/src/types/runtime_sized_array.rs
@@ -264,7 +264,7 @@ mod array_length {
 
     #[test]
     fn derived_traits() {
-        assert_eq!(ArrayLength::default(), ArrayLength.clone());
+        assert_eq!(ArrayLength, ArrayLength.clone());
 
         assert_eq!(format!("{ArrayLength:?}"), "ArrayLength");
     }


### PR DESCRIPTION
Remove offline param or else the version selected might not be the minimal (see also https://github.com/gfx-rs/naga/pull/2429).

Should avoid the need for https://github.com/teoxoy/encase/pull/47 in the future.