### PR TITLE
Add support for u64

### DIFF
--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -7,9 +7,12 @@ use core::sync::atomic::{AtomicI32, AtomicU32};
 
 macro_rules! impl_basic_traits {
     ($type:ty) => {
+        impl_basic_traits!($type, size = 4, alignment = 4);
+    };
+    ($type:ty, size = $size:literal, alignment = $alignment:literal) => {
         impl ShaderType for $type {
             type ExtraMetadata = ();
-            const METADATA: Metadata<Self::ExtraMetadata> = Metadata::from_alignment_and_size(4, 4);
+            const METADATA: Metadata<Self::ExtraMetadata> = Metadata::from_alignment_and_size($alignment, $size);
         }
 
         impl ShaderSize for $type {}
@@ -18,7 +21,10 @@ macro_rules! impl_basic_traits {
 
 macro_rules! impl_traits {
     ($type:ty) => {
-        impl_basic_traits!($type);
+        impl_traits!($type, size = 4, alignment = 4);
+    };
+    ($type:ty, size = $size:literal, alignment = $alignment:literal) => {
+        impl_basic_traits!($type, size = $size, alignment = $alignment);
 
         impl WriteInto for $type {
             #[inline]
@@ -45,6 +51,7 @@ macro_rules! impl_traits {
 
 impl_traits!(f32);
 impl_traits!(u32);
+impl_traits!(u64, size = 8, alignment = 8);
 impl_traits!(i32);
 
 macro_rules! impl_traits_for_non_zero_option {
@@ -152,6 +159,13 @@ macro_rules! impl_marker_trait_for_u32 {
         impl $trait for ::core::option::Option<::core::num::NonZeroU32> {}
         impl $trait for ::core::num::Wrapping<::core::primitive::u32> {}
         impl $trait for ::core::sync::atomic::AtomicU32 {}
+    };
+}
+
+macro_rules! impl_marker_trait_for_u64 {
+    ($trait:path) => {
+        impl $trait for ::core::primitive::u64 {}
+        impl $trait for ::core::num::Wrapping<::core::primitive::u64> {}
     };
 }
 

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -1,6 +1,7 @@
 pub trait VectorScalar {}
 impl_marker_trait_for_f32!(VectorScalar);
 impl_marker_trait_for_u32!(VectorScalar);
+impl_marker_trait_for_u64!(VectorScalar);
 impl_marker_trait_for_i32!(VectorScalar);
 
 /// Enables reading from the vector (via `&[T; N]`)

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -1,8 +1,11 @@
 use encase::{ArrayLength, CalculateSizeFor, ShaderType, StorageBuffer};
 
 macro_rules! gen {
-    ($rng:ident, $ty:ty) => {{
-        let mut buf = [0; 4];
+    ($rng:ident, $ty:ty) => {
+        gen!($rng, $ty, size = 4)
+    };
+    ($rng:ident, $ty:ty, size = $size:literal) => {{
+        let mut buf = [0; $size];
         use rand::RngCore;
         $rng.fill_bytes(&mut buf);
         <$ty>::from_ne_bytes(buf)
@@ -10,8 +13,11 @@ macro_rules! gen {
 }
 
 macro_rules! gen_arr {
-    ($rng:ident, $ty:ty, $n:literal) => {{
-        [(); $n].map(|_| gen!($rng, $ty))
+    ($rng:ident, $ty:ty, $n:literal) => {
+        gen_arr!($rng, $ty, $n, size = 4)
+    };
+    ($rng:ident, $ty:ty, $n:literal, size = $size:literal) => {{
+        [(); $n].map(|_| gen!($rng, $ty, size = $size))
     }};
 }
 
@@ -31,6 +37,7 @@ macro_rules! gen_inner {
 struct A {
     f: f32,
     u: u32,
+    uu: u64,
     i: i32,
     nu: Option<core::num::NonZeroU32>,
     ni: Option<core::num::NonZeroI32>,
@@ -54,6 +61,7 @@ struct A {
     mat4: mint::ColumnMatrix4<f32>,
     arrf: [f32; 32],
     arru: [u32; 32],
+    arruu: [u64; 32],
     arri: [i32; 32],
     arrvf: [mint::Vector2<f32>; 16],
     arrvu: [mint::Vector3<u32>; 16],
@@ -70,6 +78,7 @@ fn gen_a(rng: &mut rand::rngs::StdRng) -> A {
     A {
         f: gen!(rng, f32),
         u: gen!(rng, u32),
+        uu: gen!(rng, u64, size = 8),
         i: gen!(rng, i32),
         nu: core::num::NonZeroU32::new(gen!(rng, u32)),
         ni: core::num::NonZeroI32::new(gen!(rng, i32)),
@@ -93,6 +102,7 @@ fn gen_a(rng: &mut rand::rngs::StdRng) -> A {
         mat4: mint::ColumnMatrix4::from(gen_2d_arr!(rng, f32, 4, 4)),
         arrf: gen_arr!(rng, f32, 32),
         arru: gen_arr!(rng, u32, 32),
+        arruu: gen_arr!(rng, u64, 32, size = 8),
         arri: gen_arr!(rng, i32, 32),
         arrvf: gen_inner!(16, mint::Vector2::from(gen_arr!(rng, f32, 2))),
         arrvu: gen_inner!(16, mint::Vector3::from(gen_arr!(rng, u32, 3))),


### PR DESCRIPTION
It turns out that timestamp queries return unsigned 64-bit values, so it would be nice if encase knew about `u64`.

This PR is broken and I don't really understand what's going on.