### PR TITLE
traits for buffers and BufferContent trait and implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The [`UniformBuffer`], [`StorageBuffer`], [`DynamicUniformBuffer`] and [`Dynamic
 Write affine transform to uniform buffer
 
 ```rust
-use encase::{Buffer, ShaderType, UniformBuffer, WritebleBuffer};
+use encase::{Buffer, ShaderType, UniformBuffer, WritableBuffer};
 
 #[derive(ShaderType)]
 struct AffineTransform2D {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The [`UniformBuffer`], [`StorageBuffer`], [`DynamicUniformBuffer`] and [`Dynamic
 Write affine transform to uniform buffer
 
 ```rust
-use encase::{ShaderType, UniformBuffer};
+use encase::{Buffer, ShaderType, UniformBuffer, WritebleBuffer};
 
 #[derive(ShaderType)]
 struct AffineTransform2D {
@@ -61,7 +61,7 @@ assert_eq!(&byte_buffer, &[0, 0, 128, 63, 0, 0, 0, 0,
 Create vector instance by reading from dynamic uniform buffer at specific offset
 
 ```rust
-use encase::DynamicUniformBuffer;
+use encase::{Buffer, DynamicUniformBuffer, MutReadableBuffer};
 
 // read byte_buffer from GPU
 let byte_buffer = [1u8; 256 + 8];
@@ -76,7 +76,7 @@ assert_eq!(vector, mint::Vector2 { x: 16843009, y: 16843009 });
 Write and read back data from storage buffer
 
 ```rust
-use encase::{ShaderType, ArrayLength, StorageBuffer};
+use encase::{Buffer, ReadableBuffer, ShaderType, ArrayLength, StorageBuffer, WritableBuffer};
 
 #[derive(ShaderType)]
 struct Positions {
@@ -116,7 +116,7 @@ assert_eq!(positions.positions.len(), 2);
 Write different data types to dynamic storage buffer
 
 ```rust
-use encase::{ShaderType, DynamicStorageBuffer};
+use encase::{ShaderType, DynamicStorageBuffer, WritableBuffer};
 
 let mut byte_buffer = Vec::new();
 

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use encase::{ShaderType, StorageBuffer};
+use encase::{Buffer, ShaderType, StorageBuffer, WritableBuffer};
 use pprof::criterion::{Output, PProfProfiler};
 
 #[global_allocator]

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use encase::{Buffer, ShaderType, StorageBuffer, WritableBuffer};
+use encase::{Buffer, ReadableBuffer, ShaderType, StorageBuffer, WritableBuffer};
 use pprof::criterion::{Output, PProfProfiler};
 
 #[global_allocator]

--- a/src/core/buffers.rs
+++ b/src/core/buffers.rs
@@ -174,6 +174,7 @@ pub struct DynamicStorageBuffer<B> {
 
 impl<B> Buffer for DynamicStorageBuffer<B> {
     type B = B;
+
     /// Creates a new dynamic storage buffer wrapper with an alignment of 256
     /// (default alignment in the WebGPU spec).
     fn new(buffer: B) -> Self {
@@ -282,6 +283,7 @@ pub struct DynamicUniformBuffer<B> {
 
 impl<B> Buffer for DynamicUniformBuffer<B> {
     type B = B;
+
     /// Creates a new dynamic uniform buffer wrapper with an alignment of 256
     /// (default alignment in the WebGPU spec).
     fn new(buffer: B) -> Self {

--- a/src/core/buffers.rs
+++ b/src/core/buffers.rs
@@ -359,14 +359,17 @@ impl<B: BufferRef> MutReadableBuffer for DynamicUniformBuffer<B> {
     }
 }
 
-pub trait BufferContent {
+trait BufferContent {
     fn buffer_content<BufferType: Buffer<B = Vec<u8>> + WritableBuffer>(&self) -> Vec<u8>;
 }
 
-impl<T> BufferContent for T where T: ShaderType + WriteInto {
+impl<T> BufferContent for T
+where
+    T: ShaderType + WriteInto,
+{
     fn buffer_content<BufferType: Buffer<B = Vec<u8>> + WritableBuffer>(&self) -> Vec<u8> {
         let mut buffer = BufferType::new(Vec::new());
         buffer.write(self).unwrap();
-        return buffer.into_inner();
+        buffer.into_inner()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,8 @@ mod types;
 mod impls;
 
 pub use crate::core::{
-    CalculateSizeFor, DynamicStorageBuffer, DynamicUniformBuffer, ShaderSize, ShaderType,
-    StorageBuffer, UniformBuffer, Buffer, WritableBuffer, ReadableBuffer, MutReadableBuffer,
+    Buffer, CalculateSizeFor, DynamicStorageBuffer, DynamicUniformBuffer, MutReadableBuffer,
+    ReadableBuffer, ShaderSize, ShaderType, StorageBuffer, UniformBuffer, WritableBuffer,
 };
 pub use types::runtime_sized_array::ArrayLength;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ mod impls;
 
 pub use crate::core::{
     CalculateSizeFor, DynamicStorageBuffer, DynamicUniformBuffer, ShaderSize, ShaderType,
-    StorageBuffer, UniformBuffer,
+    StorageBuffer, UniformBuffer, Buffer, WritableBuffer, ReadableBuffer, MutReadableBuffer,
 };
 pub use types::runtime_sized_array::ArrayLength;
 

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,4 +1,4 @@
-use encase::{internal::Error, ShaderType, StorageBuffer};
+use encase::{internal::Error, ShaderType, StorageBuffer, Buffer};
 
 #[test]
 fn buffer_too_small() {

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,4 +1,4 @@
-use encase::{internal::Error, ShaderType, StorageBuffer, Buffer, WritableBuffer, ReadableBuffer};
+use encase::{internal::Error, Buffer, ReadableBuffer, ShaderType, StorageBuffer, WritableBuffer};
 
 #[test]
 fn buffer_too_small() {

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,4 +1,4 @@
-use encase::{internal::Error, ShaderType, StorageBuffer, Buffer};
+use encase::{internal::Error, ShaderType, StorageBuffer, Buffer, WritableBuffer, ReadableBuffer};
 
 #[test]
 fn buffer_too_small() {

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -1,4 +1,7 @@
-use encase::{ArrayLength, CalculateSizeFor, ShaderType, StorageBuffer};
+use encase::{
+    ArrayLength, Buffer, CalculateSizeFor, ReadableBuffer, ShaderType, StorageBuffer,
+    WritableBuffer,
+};
 
 macro_rules! gen {
     ($rng:ident, $ty:ty) => {{

--- a/tests/uniform.rs
+++ b/tests/uniform.rs
@@ -1,4 +1,4 @@
-use encase::{ShaderType, UniformBuffer};
+use encase::{ShaderType, UniformBuffer, Buffer};
 
 #[derive(Debug, ShaderType, PartialEq, Eq)]
 struct TestUniform {

--- a/tests/uniform.rs
+++ b/tests/uniform.rs
@@ -1,4 +1,4 @@
-use encase::{ShaderType, UniformBuffer, Buffer, WritableBuffer, ReadableBuffer};
+use encase::{Buffer, ReadableBuffer, ShaderType, UniformBuffer, WritableBuffer};
 
 #[derive(Debug, ShaderType, PartialEq, Eq)]
 struct TestUniform {

--- a/tests/uniform.rs
+++ b/tests/uniform.rs
@@ -1,4 +1,4 @@
-use encase::{ShaderType, UniformBuffer, Buffer};
+use encase::{ShaderType, UniformBuffer, Buffer, WritableBuffer, ReadableBuffer};
 
 #[derive(Debug, ShaderType, PartialEq, Eq)]
 struct TestUniform {

--- a/tests/wgpu.rs
+++ b/tests/wgpu.rs
@@ -1,4 +1,4 @@
-use encase::{ArrayLength, ShaderType, StorageBuffer};
+use encase::{ArrayLength, Buffer, ShaderType, StorageBuffer, WritableBuffer};
 use futures::executor::block_on;
 use mint::{Vector2, Vector3};
 use wgpu::{include_wgsl, util::DeviceExt};

--- a/tests/wgpu.rs
+++ b/tests/wgpu.rs
@@ -1,4 +1,4 @@
-use encase::{ArrayLength, Buffer, ShaderType, StorageBuffer, WritableBuffer};
+use encase::{ArrayLength, Buffer, ReadableBuffer, ShaderType, StorageBuffer, WritableBuffer};
 use futures::executor::block_on;
 use mint::{Vector2, Vector3};
 use wgpu::{include_wgsl, util::DeviceExt};


### PR DESCRIPTION
Changed the repeated behaviour of buffers into traits Buffer, WritableBuffer and ReadableBuffer.
Added a BufferContent trait to get the content of a buffer with some data. This would be useful to make writing uniform data to GPU buffers simpler.