### PR TITLE
Buffercontenttraitonly

### DIFF
--- a/src/core/buffers.rs
+++ b/src/core/buffers.rs
@@ -316,7 +316,7 @@ impl<B: BufferRef> DynamicUniformBuffer<B> {
     }
 }
 
-trait StorageBufferContent {
+pub trait StorageBufferContent {
     fn buffer_content(&self) -> Vec<u8>;
 }
 
@@ -331,7 +331,7 @@ where
     }
 }
 
-trait UniformBufferContent {
+pub trait UniformBufferContent {
     fn buffer_content(&self) -> Vec<u8>;
 }
 

--- a/src/core/buffers.rs
+++ b/src/core/buffers.rs
@@ -315,3 +315,33 @@ impl<B: BufferRef> DynamicUniformBuffer<B> {
         self.inner.create()
     }
 }
+
+trait StorageBufferContent {
+    fn buffer_content(&self) -> Vec<u8>;
+}
+
+impl<T> StorageBufferContent for T
+where
+    T: ShaderType + WriteInto,
+{
+    fn buffer_content(&self) -> Vec<u8> {
+        let mut buffer = StorageBuffer::new(Vec::new());
+        buffer.write(self).unwrap();
+        buffer.into_inner()
+    }
+}
+
+trait UniformBufferContent {
+    fn buffer_content(&self) -> Vec<u8>;
+}
+
+impl<T> UniformBufferContent for T
+where
+    T: ShaderType + WriteInto,
+{
+    fn buffer_content(&self) -> Vec<u8> {
+        let mut buffer = UniformBuffer::new(Vec::new());
+        buffer.write(self).unwrap();
+        buffer.into_inner()
+    }
+}


### PR DESCRIPTION
Added traits that allow the user to quickly get the buffer contents for a value. This would be convenient for writing data to GPU buffers.