### PR TITLE
Direct copy specialization

### DIFF
--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -594,7 +594,7 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
                     alignment: struct_alignment,
                     has_uniform_min_alignment: true,
                     min_size,
-                    has_internal_padding: true,
+                    is_pod: false,
                     extra,
                 }
             };

--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -615,6 +615,7 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
             Self: #root::ShaderType<ExtraMetadata = #root::StructMetadata<#nr_of_fields>>,
             #( for<'__> #field_types_2: #root::WriteInto, )*
         {
+            #[inline]
             fn write_into<B: #root::BufferMut>(&self, writer: &mut #root::Writer<B>) {
                 #set_contained_rt_sized_array_length
                 #( #write_into_buffer_body )*
@@ -626,6 +627,7 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
             Self: #root::ShaderType<ExtraMetadata = #root::StructMetadata<#nr_of_fields>>,
             #( for<'__> #field_types_3: #root::ReadFrom, )*
         {
+            #[inline]
             fn read_from<B: #root::BufferRef>(&mut self, reader: &mut #root::Reader<B>) {
                 #( #read_from_buffer_body )*
             }
@@ -636,6 +638,7 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
             Self: #root::ShaderType<ExtraMetadata = #root::StructMetadata<#nr_of_fields>>,
             #( for<'__> #field_types_4: #root::CreateFrom, )*
         {
+            #[inline]
             fn create_from<B: #root::BufferRef>(reader: &mut #root::Reader<B>) -> Self {
                 #( #create_from_buffer_body )*
 

--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -594,6 +594,7 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
                     alignment: struct_alignment,
                     has_uniform_min_alignment: true,
                     min_size,
+                    has_internal_padding: true,
                     extra,
                 }
             };

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -8,15 +8,21 @@ pub struct Metadata<E> {
     pub alignment: AlignmentValue,
     pub has_uniform_min_alignment: bool,
     pub min_size: SizeValue,
+    pub has_internal_padding: bool,
     pub extra: E,
 }
 
 impl Metadata<()> {
-    pub const fn from_alignment_and_size(alignment: u64, size: u64) -> Self {
+    pub const fn from_alignment_and_size(
+        alignment: u64,
+        size: u64,
+        has_internal_padding: bool,
+    ) -> Self {
         Self {
             alignment: AlignmentValue::new(alignment),
             has_uniform_min_alignment: false,
             min_size: SizeValue::new(size),
+            has_internal_padding,
             extra: (),
         }
     }
@@ -41,6 +47,13 @@ impl<E> Metadata<E> {
             true => Some(UNIFORM_MIN_ALIGNMENT),
             false => None,
         }
+    }
+
+    #[inline]
+    pub const fn has_internal_padding(self) -> bool {
+        let value = self.has_internal_padding;
+        core::mem::forget(self);
+        value
     }
 
     #[inline]

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -8,21 +8,17 @@ pub struct Metadata<E> {
     pub alignment: AlignmentValue,
     pub has_uniform_min_alignment: bool,
     pub min_size: SizeValue,
-    pub has_internal_padding: bool,
+    pub is_pod: bool,
     pub extra: E,
 }
 
 impl Metadata<()> {
-    pub const fn from_alignment_and_size(
-        alignment: u64,
-        size: u64,
-        has_internal_padding: bool,
-    ) -> Self {
+    pub const fn from_alignment_and_size(alignment: u64, size: u64) -> Self {
         Self {
             alignment: AlignmentValue::new(alignment),
             has_uniform_min_alignment: false,
             min_size: SizeValue::new(size),
-            has_internal_padding,
+            is_pod: false,
             extra: (),
         }
     }
@@ -50,17 +46,29 @@ impl<E> Metadata<E> {
     }
 
     #[inline]
-    pub const fn has_internal_padding(self) -> bool {
-        let value = self.has_internal_padding;
+    pub const fn min_size(self) -> SizeValue {
+        let value = self.min_size;
         core::mem::forget(self);
         value
     }
 
     #[inline]
-    pub const fn min_size(self) -> SizeValue {
-        let value = self.min_size;
+    pub const fn is_pod(self) -> bool {
+        let value = self.is_pod;
         core::mem::forget(self);
         value
+    }
+
+    #[inline]
+    pub const fn pod(mut self) -> Self {
+        self.is_pod = true;
+        self
+    }
+
+    #[inline]
+    pub const fn no_pod(mut self) -> Self {
+        self.is_pod = false;
+        self
     }
 }
 

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -75,7 +75,7 @@ where
                     writer.advance(Self::METADATA.el_padding() as usize);
                 }
             } else {
-                let ptr = self.as_ptr() as *const u8;
+                let ptr = self.as_ptr() as *const ::core::primitive::u8;
                 let byte_slice: &[::core::primitive::u8] =
                     unsafe { ::core::slice::from_raw_parts(ptr, ::core::mem::size_of::<Self>()) };
                 writer.write_slice(byte_slice);

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -75,9 +75,9 @@ where
                     writer.advance(Self::METADATA.el_padding() as usize);
                 }
             } else {
-                let size = ::core::mem::size_of::<Self>();
-                let byte_slice: &[u8] =
-                    unsafe { ::core::slice::from_raw_parts(self.as_ptr() as *const u8, size) };
+                let ptr = self.as_ptr() as *const u8;
+                let byte_slice: &[::core::primitive::u8] =
+                    unsafe { ::core::slice::from_raw_parts(ptr, ::core::mem::size_of::<Self>()) };
                 writer.write_slice(byte_slice);
             }
         }

--- a/src/types/matrix.rs
+++ b/src/types/matrix.rs
@@ -158,7 +158,7 @@ macro_rules! impl_matrix_inner {
         impl<$($generics)*> $crate::private::WriteInto for $type
         where
             Self: $crate::private::AsRefMatrixParts<$el_ty, $c, $r> + $crate::private::ShaderType<ExtraMetadata = $crate::private::MatrixMetadata>,
-            $el_ty: $crate::private::MatrixScalar + $crate::private::WriteInto,
+            $el_ty: $crate::private::MatrixScalar + $crate::private::WriteInto + $crate::private::ShaderSize,
         {
             #[inline]
             #[allow(trivial_casts)]
@@ -169,9 +169,7 @@ macro_rules! impl_matrix_inner {
                     // Const branch, should be eliminated at compile time.
                     if <Self as $crate::private::ShaderType>::METADATA.has_internal_padding() {
                         for col in columns {
-                            for el in col {
-                                $crate::private::WriteInto::write_into(el, writer);
-                            }
+                            $crate::private::WriteInto::write_into(col, writer);
                             writer.advance(<Self as $crate::private::ShaderType>::METADATA.col_padding() as ::core::primitive::usize);
                         }
                     } else {
@@ -185,7 +183,7 @@ macro_rules! impl_matrix_inner {
                 #[cfg(not(target_endian = "little"))]
                 {
                     for col in columns {
-                        WriteInto::write_into(col, writer);
+                        $crate::private::WriteInto::write_into(col, writer);
                         writer.advance(Self::METADATA.el_padding() as usize);
                     }
                 }
@@ -195,7 +193,7 @@ macro_rules! impl_matrix_inner {
         impl<$($generics)*> $crate::private::ReadFrom for $type
         where
             Self: $crate::private::AsMutMatrixParts<$el_ty, $c, $r> + $crate::private::ShaderType<ExtraMetadata = $crate::private::MatrixMetadata>,
-            $el_ty: $crate::private::MatrixScalar + $crate::private::ReadFrom,
+            $el_ty: $crate::private::MatrixScalar + $crate::private::ReadFrom + $crate::private::ShaderSize,
         {
             #[inline]
             #[allow(trivial_casts)]
@@ -206,9 +204,7 @@ macro_rules! impl_matrix_inner {
                     // Const branch, should be eliminated at compile time.
                     if <Self as $crate::private::ShaderType>::METADATA.has_internal_padding() {
                         for col in columns {
-                            for el in col {
-                                $crate::private::ReadFrom::read_from(el, reader);
-                            }
+                            $crate::private::ReadFrom::read_from(col, reader);
                             reader.advance(<Self as $crate::private::ShaderType>::METADATA.col_padding() as ::core::primitive::usize);
                         }
                     } else {
@@ -221,9 +217,7 @@ macro_rules! impl_matrix_inner {
                 #[cfg(not(target_endian = "little"))]
                 {
                     for col in columns {
-                        for el in col {
-                            $crate::private::ReadFrom::read_from(el, reader);
-                        }
+                        $crate::private::ReadFrom::read_from(col, reader);
                         reader.advance(Self::METADATA.el_padding() as usize);
                     }
                 }
@@ -233,7 +227,7 @@ macro_rules! impl_matrix_inner {
         impl<$($generics)*> $crate::private::CreateFrom for $type
         where
             Self: $crate::private::FromMatrixParts<$el_ty, $c, $r> + $crate::private::ShaderType<ExtraMetadata = $crate::private::MatrixMetadata>,
-            $el_ty: $crate::private::MatrixScalar + $crate::private::CreateFrom,
+            $el_ty: $crate::private::MatrixScalar + $crate::private::CreateFrom + $crate::private::ShaderSize,
         {
             #[inline]
             fn create_from<B: $crate::private::BufferRef>(reader: &mut $crate::private::Reader<B>) -> Self {
@@ -242,9 +236,7 @@ macro_rules! impl_matrix_inner {
                     // Const branch, should be eliminated at compile time.
                     if <Self as $crate::private::ShaderType>::METADATA.has_internal_padding() {
                         let columns = ::core::array::from_fn(|_| {
-                            let col = ::core::array::from_fn(|_| {
-                                $crate::private::CreateFrom::create_from(reader)
-                            });
+                            let col = $crate::private::CreateFrom::create_from(reader);
                             reader.advance(<Self as $crate::private::ShaderType>::METADATA.col_padding() as ::core::primitive::usize);
                             col
                         });
@@ -265,9 +257,7 @@ macro_rules! impl_matrix_inner {
                 #[cfg(not(target_endian = "little"))]
                 {
                     let columns = ::core::array::from_fn(|_| {
-                        let col = ::core::array::from_fn(|_| {
-                            $crate::private::CreateFrom::create_from(reader)
-                        });
+                        let col = $crate::private::CreateFrom::create_from(reader);
                         reader.advance(<Self as $crate::private::ShaderType>::METADATA.col_padding() as ::core::primitive::usize);
                         col
                     });

--- a/src/types/matrix.rs
+++ b/src/types/matrix.rs
@@ -175,7 +175,7 @@ macro_rules! impl_matrix_inner {
                             writer.advance(<Self as $crate::private::ShaderType>::METADATA.col_padding() as ::core::primitive::usize);
                         }
                     } else {
-                        let ptr = (self as *const Self) as *const u8;
+                        let ptr = (self as *const Self) as *const ::core::primitive::u8;
                         let byte_slice: &[::core::primitive::u8] = unsafe {
                             ::core::slice::from_raw_parts(ptr, ::core::mem::size_of::<Self>())
                         };

--- a/src/types/matrix.rs
+++ b/src/types/matrix.rs
@@ -175,10 +175,10 @@ macro_rules! impl_matrix_inner {
                             writer.advance(<Self as $crate::private::ShaderType>::METADATA.col_padding() as ::core::primitive::usize);
                         }
                     } else {
-                        let size = ::core::mem::size_of::<Self>();
                         let ptr = (self as *const Self) as *const u8;
-                        let byte_slice: &[u8] =
-                            unsafe { ::core::slice::from_raw_parts(ptr, size) };
+                        let byte_slice: &[::core::primitive::u8] = unsafe {
+                            ::core::slice::from_raw_parts(ptr, ::core::mem::size_of::<Self>())
+                        };
                         writer.write_slice(byte_slice);
                     }
                 }

--- a/src/types/matrix.rs
+++ b/src/types/matrix.rs
@@ -167,17 +167,13 @@ macro_rules! impl_matrix_inner {
                 #[cfg(target_endian = "little")]
                 {
                     // Const branch, should be eliminated at compile time.
-                    if <Self as $crate::private::ShaderType>::METADATA.has_internal_padding() {
+                    if <Self as $crate::private::ShaderType>::METADATA.col_padding() != 0 {
                         for col in columns {
                             $crate::private::WriteInto::write_into(col, writer);
                             writer.advance(<Self as $crate::private::ShaderType>::METADATA.col_padding() as ::core::primitive::usize);
                         }
                     } else {
-                        let ptr = (self as *const Self) as *const ::core::primitive::u8;
-                        let byte_slice: &[::core::primitive::u8] = unsafe {
-                            ::core::slice::from_raw_parts(ptr, ::core::mem::size_of::<Self>())
-                        };
-                        writer.write_slice(byte_slice);
+                        $crate::private::WriteInto::write_into(columns, writer);
                     }
                 }
                 #[cfg(not(target_endian = "little"))]

--- a/src/types/matrix.rs
+++ b/src/types/matrix.rs
@@ -142,6 +142,7 @@ macro_rules! impl_matrix_inner {
                     alignment,
                     has_uniform_min_alignment: false,
                     min_size: size,
+                    has_internal_padding: <$el_ty as $crate::private::ShaderType>::METADATA.has_internal_padding() || col_padding != 0,
                     extra: $crate::private::MatrixMetadata {
                         col_padding,
                     },

--- a/src/types/runtime_sized_array.rs
+++ b/src/types/runtime_sized_array.rs
@@ -33,7 +33,7 @@ pub struct ArrayLength;
 
 impl ShaderType for ArrayLength {
     type ExtraMetadata = ();
-    const METADATA: Metadata<Self::ExtraMetadata> = Metadata::from_alignment_and_size(4, 4, false);
+    const METADATA: Metadata<Self::ExtraMetadata> = Metadata::from_alignment_and_size(4, 4);
 }
 
 impl ShaderSize for ArrayLength {}
@@ -137,7 +137,7 @@ macro_rules! impl_rts_array_inner {
                     alignment,
                     has_uniform_min_alignment: true,
                     min_size: el_size,
-                    has_internal_padding: T::METADATA.has_internal_padding() || el_padding != 0,
+                    is_pod: false,
                     extra: $crate::private::ArrayMetadata { stride, el_padding },
                 }
             };

--- a/src/types/runtime_sized_array.rs
+++ b/src/types/runtime_sized_array.rs
@@ -33,7 +33,7 @@ pub struct ArrayLength;
 
 impl ShaderType for ArrayLength {
     type ExtraMetadata = ();
-    const METADATA: Metadata<Self::ExtraMetadata> = Metadata::from_alignment_and_size(4, 4);
+    const METADATA: Metadata<Self::ExtraMetadata> = Metadata::from_alignment_and_size(4, 4, false);
 }
 
 impl ShaderSize for ArrayLength {}
@@ -137,6 +137,7 @@ macro_rules! impl_rts_array_inner {
                     alignment,
                     has_uniform_min_alignment: true,
                     min_size: el_size,
+                    has_internal_padding: T::METADATA.has_internal_padding() || el_padding != 0,
                     extra: $crate::private::ArrayMetadata { stride, el_padding },
                 }
             };

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -7,19 +7,24 @@ use core::sync::atomic::{AtomicI32, AtomicU32};
 
 macro_rules! impl_basic_traits {
     ($type:ty) => {
+        impl_basic_traits!(__main, $type, );
+    };
+    ($type:ty, is_pod) => {
+        impl_basic_traits!(__main, $type, .pod());
+    };
+    (__main, $type:ty, $($tail:tt)*) => {
         impl ShaderType for $type {
             type ExtraMetadata = ();
-            const METADATA: Metadata<Self::ExtraMetadata> =
-                Metadata::from_alignment_and_size(4, 4, false);
+            const METADATA: Metadata<Self::ExtraMetadata> = Metadata::from_alignment_and_size(4, 4) $($tail)*;
         }
 
         impl ShaderSize for $type {}
     };
 }
 
-macro_rules! impl_traits {
+macro_rules! impl_traits_for_pod {
     ($type:ty) => {
-        impl_basic_traits!($type);
+        impl_basic_traits!($type, is_pod);
 
         impl WriteInto for $type {
             #[inline]
@@ -44,9 +49,9 @@ macro_rules! impl_traits {
     };
 }
 
-impl_traits!(f32);
-impl_traits!(u32);
-impl_traits!(i32);
+impl_traits_for_pod!(f32);
+impl_traits_for_pod!(u32);
+impl_traits_for_pod!(i32);
 
 macro_rules! impl_traits_for_non_zero_option {
     ($type:ty) => {
@@ -149,7 +154,6 @@ macro_rules! impl_marker_trait_for_f32 {
 macro_rules! impl_marker_trait_for_u32 {
     ($trait:path) => {
         impl $trait for ::core::primitive::u32 {}
-        impl $trait for ::core::num::NonZeroU32 {}
         impl $trait for ::core::option::Option<::core::num::NonZeroU32> {}
         impl $trait for ::core::num::Wrapping<::core::primitive::u32> {}
         impl $trait for ::core::sync::atomic::AtomicU32 {}
@@ -159,7 +163,6 @@ macro_rules! impl_marker_trait_for_u32 {
 macro_rules! impl_marker_trait_for_i32 {
     ($trait:path) => {
         impl $trait for ::core::primitive::i32 {}
-        impl $trait for ::core::num::NonZeroI32 {}
         impl $trait for ::core::option::Option<::core::num::NonZeroI32> {}
         impl $trait for ::core::num::Wrapping<::core::primitive::i32> {}
         impl $trait for ::core::sync::atomic::AtomicI32 {}

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -9,7 +9,8 @@ macro_rules! impl_basic_traits {
     ($type:ty) => {
         impl ShaderType for $type {
             type ExtraMetadata = ();
-            const METADATA: Metadata<Self::ExtraMetadata> = Metadata::from_alignment_and_size(4, 4);
+            const METADATA: Metadata<Self::ExtraMetadata> =
+                Metadata::from_alignment_and_size(4, 4, false);
         }
 
         impl ShaderSize for $type {}

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -123,6 +123,7 @@ macro_rules! impl_vector_inner {
                     alignment,
                     has_uniform_min_alignment: false,
                     min_size: size,
+                    has_internal_padding: <[$el_ty; $n] as $crate::private::ShaderType>::METADATA.has_internal_padding(),
                     extra: ()
                 }
             };

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -151,8 +151,9 @@ macro_rules! impl_vector_inner {
                         }
                     } else {
                         let ptr: *const Self = self;
+                        let ptr = ptr.cast::<::core::primitive::u8>();
                         let byte_slice: &[::core::primitive::u8] = unsafe {
-                            ::core::slice::from_raw_parts(ptr.cast::<u8>(), ::core::mem::size_of::<Self>())
+                            ::core::slice::from_raw_parts(ptr, ::core::mem::size_of::<Self>())
                         };
                         writer.write_slice(byte_slice);
                     }

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -142,9 +142,7 @@ macro_rules! impl_vector_inner {
             #[inline]
             fn write_into<B: $crate::private::BufferMut>(&self, writer: &mut $crate::private::Writer<B>) {
                 let elements = $crate::private::AsRefVectorParts::<$el_ty, $n>::as_ref_parts(self);
-                for el in elements {
-                    $crate::private::WriteInto::write_into(el, writer);
-                }
+                $crate::private::WriteInto::write_into(elements, writer);
             }
         }
 

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -141,30 +141,8 @@ macro_rules! impl_vector_inner {
         {
             #[inline]
             fn write_into<B: $crate::private::BufferMut>(&self, writer: &mut $crate::private::Writer<B>) {
-                #[cfg(target_endian = "little")]
-                {
-                    // Const branch, should be eliminated at compile time.
-                    if <Self as $crate::private::ShaderType>::METADATA.has_internal_padding() {
-                        let elements = $crate::private::AsRefVectorParts::<$el_ty, $n>::as_ref_parts(self);
-                        for el in elements {
-                            $crate::private::WriteInto::write_into(el, writer);
-                        }
-                    } else {
-                        let ptr: *const Self = self;
-                        let ptr = ptr.cast::<::core::primitive::u8>();
-                        let byte_slice: &[::core::primitive::u8] = unsafe {
-                            ::core::slice::from_raw_parts(ptr, ::core::mem::size_of::<Self>())
-                        };
-                        writer.write_slice(byte_slice);
-                    }
-                }
-                #[cfg(not(target_endian = "little"))]
-                {
-                    let elements = $crate::private::AsRefVectorParts::<$el_ty, $n>::as_ref_parts(self);
-                    for el in elements {
-                        $crate::private::WriteInto::write_into(el, writer);
-                    }
-                }
+                let elements = $crate::private::AsRefVectorParts::<$el_ty, $n>::as_ref_parts(self);
+                $crate::private::WriteInto::write_into(elements, writer);
             }
         }
 
@@ -175,30 +153,8 @@ macro_rules! impl_vector_inner {
         {
             #[inline]
             fn read_from<B: $crate::private::BufferRef>(&mut self, reader: &mut $crate::private::Reader<B>) {
-                #[cfg(target_endian = "little")]
-                {
-                    // Const branch, should be eliminated at compile time.
-                    if <Self as $crate::private::ShaderType>::METADATA.has_internal_padding() {
-                        let elements = $crate::private::AsMutVectorParts::<$el_ty, $n>::as_mut_parts(self);
-                        for el in elements {
-                            $crate::private::ReadFrom::read_from(el, reader);
-                        }
-                    } else {
-                        let ptr: *mut Self = self;
-                        let ptr = ptr.cast::<::core::primitive::u8>();
-                        let byte_slice: &mut [::core::primitive::u8] = unsafe {
-                            ::core::slice::from_raw_parts_mut(ptr, ::core::mem::size_of::<Self>())
-                        };
-                        reader.read_slice(byte_slice);
-                    }
-                }
-                #[cfg(not(target_endian = "little"))]
-                {
-                    let elements = $crate::private::AsRefVectorParts::<$el_ty, $n>::as_ref_parts(self);
-                    for el in elements {
-                        $crate::private::ReadFrom::read_from(el, reader);
-                    }
-                }
+                let elements = $crate::private::AsMutVectorParts::<$el_ty, $n>::as_mut_parts(self);
+                $crate::private::ReadFrom::read_from(elements, reader);
             }
         }
 
@@ -210,34 +166,8 @@ macro_rules! impl_vector_inner {
             #[inline]
             #[allow(trivial_casts)]
             fn create_from<B: $crate::private::BufferRef>(reader: &mut $crate::private::Reader<B>) -> Self {
-                #[cfg(target_endian = "little")]
-                {
-                    // Const branch, should be eliminated at compile time.
-                    if <Self as $crate::private::ShaderType>::METADATA.has_internal_padding() {
-                        let elements = ::core::array::from_fn(|_| {
-                            $crate::private::CreateFrom::create_from(reader)
-                        });
-
-                        $crate::private::FromVectorParts::<$el_ty, $n>::from_parts(elements)
-                    } else {
-                        let mut me = ::core::mem::MaybeUninit::zeroed();
-                        let ptr = (&mut me as *mut ::core::mem::MaybeUninit<Self>).cast::<::core::primitive::u8>();
-                        let byte_slice: &mut [::core::primitive::u8] = unsafe {
-                            ::core::slice::from_raw_parts_mut(ptr, ::core::mem::size_of::<Self>())
-                        };
-                        reader.read_slice(byte_slice);
-                        // SAFETY: All values were properly initialized by reading the bytes.
-                        unsafe { me.assume_init() }
-                    }
-                }
-                #[cfg(not(target_endian = "little"))]
-                {
-                    let elements = ::core::array::from_fn(|_| {
-                        $crate::private::CreateFrom::create_from(reader)
-                    });
-
-                    $crate::private::FromVectorParts::<$el_ty, $n>::from_parts(elements)
-                }
+                let elements = $crate::private::CreateFrom::create_from(reader);
+                $crate::private::FromVectorParts::<$el_ty, $n>::from_parts(elements)
             }
         }
     };

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -150,10 +150,10 @@ macro_rules! impl_vector_inner {
                             $crate::private::WriteInto::write_into(el, writer);
                         }
                     } else {
-                        let size = ::core::mem::size_of::<Self>();
                         let ptr: *const Self = self;
-                        let byte_slice: &[u8] =
-                            unsafe { ::core::slice::from_raw_parts(ptr.cast::<u8>(), size) };
+                        let byte_slice: &[::core::primitive::u8] = unsafe {
+                            ::core::slice::from_raw_parts(ptr.cast::<u8>(), ::core::mem::size_of::<Self>())
+                        };
                         writer.write_slice(byte_slice);
                     }
                 }

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -1,4 +1,4 @@
-pub trait VectorScalar {}
+pub trait VectorScalar: crate::ShaderSize {}
 impl_marker_trait_for_f32!(VectorScalar);
 impl_marker_trait_for_u32!(VectorScalar);
 impl_marker_trait_for_i32!(VectorScalar);
@@ -123,7 +123,7 @@ macro_rules! impl_vector_inner {
                     alignment,
                     has_uniform_min_alignment: false,
                     min_size: size,
-                    has_internal_padding: <[$el_ty; $n] as $crate::private::ShaderType>::METADATA.has_internal_padding(),
+                    is_pod: <[$el_ty; $n] as $crate::private::ShaderType>::METADATA.is_pod(),
                     extra: ()
                 }
             };
@@ -137,7 +137,7 @@ macro_rules! impl_vector_inner {
         impl<$($generics)*> $crate::private::WriteInto for $type
         where
             Self: $crate::private::AsRefVectorParts<$el_ty, $n>,
-            $el_ty: $crate::private::ShaderSize + $crate::private::VectorScalar + $crate::private::WriteInto,
+            $el_ty: $crate::private::VectorScalar + $crate::private::WriteInto,
         {
             #[inline]
             fn write_into<B: $crate::private::BufferMut>(&self, writer: &mut $crate::private::Writer<B>) {
@@ -149,7 +149,7 @@ macro_rules! impl_vector_inner {
         impl<$($generics)*> $crate::private::ReadFrom for $type
         where
             Self: $crate::private::AsMutVectorParts<$el_ty, $n>,
-            $el_ty: $crate::private::ShaderSize + $crate::private::VectorScalar + $crate::private::ReadFrom,
+            $el_ty: $crate::private::VectorScalar + $crate::private::ReadFrom,
         {
             #[inline]
             fn read_from<B: $crate::private::BufferRef>(&mut self, reader: &mut $crate::private::Reader<B>) {
@@ -161,10 +161,9 @@ macro_rules! impl_vector_inner {
         impl<$($generics)*> $crate::private::CreateFrom for $type
         where
             Self: $crate::private::FromVectorParts<$el_ty, $n>,
-            $el_ty: $crate::private::ShaderSize + $crate::private::VectorScalar + $crate::private::CreateFrom,
+            $el_ty: $crate::private::VectorScalar + $crate::private::CreateFrom,
         {
             #[inline]
-            #[allow(trivial_casts)]
             fn create_from<B: $crate::private::BufferRef>(reader: &mut $crate::private::Reader<B>) -> Self {
                 let elements = $crate::private::CreateFrom::create_from(reader);
                 $crate::private::FromVectorParts::<$el_ty, $n>::from_parts(elements)

--- a/src/types/wrapper.rs
+++ b/src/types/wrapper.rs
@@ -41,7 +41,7 @@ macro_rules! impl_wrapper_inner {
             T: $crate::private::ShaderType
         {
             type ExtraMetadata = T::ExtraMetadata;
-            const METADATA: $crate::private::Metadata<Self::ExtraMetadata> = T::METADATA;
+            const METADATA: $crate::private::Metadata<Self::ExtraMetadata> = T::METADATA.no_pod();
 
             const UNIFORM_COMPAT_ASSERT: fn() = T::UNIFORM_COMPAT_ASSERT;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,6 +70,7 @@ pub(crate) trait ByteVecExt {
 }
 
 impl ByteVecExt for Vec<u8> {
+    #[inline]
     fn try_extend_zeroed(
         &mut self,
         new_len: usize,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,6 +25,24 @@ macro_rules! build_struct {
     };
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! if_pod_and_little_endian {
+    (if pod_and_little_endian $true:block else $false:block) => {{
+        #[cfg(target_endian = "little")]
+        // Const branch, should be eliminated at compile time.
+        if <Self as $crate::private::ShaderType>::METADATA.is_pod() {
+            $true
+        } else {
+            $false
+        }
+        #[cfg(not(target_endian = "little"))]
+        {
+            $false
+        }
+    }};
+}
+
 #[cfg(any(feature = "glam", feature = "ultraviolet", feature = "vek"))]
 macro_rules! array_ref_to_2d_array_ref {
     ($array:expr, $ty:ty, $c:literal, $r:literal) => {

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -143,3 +143,18 @@ fn all_types() {
 
     assert_eq!(raw_buffer, raw_buffer_2);
 }
+
+#[test]
+fn test_opt_writing() {
+    let one = 1_u32;
+    let two = 2_u32;
+    let data = [&one, &two];
+    let data2 = [one, two];
+    let mut in_byte_buffer = Vec::new();
+    let mut in_byte_buffer2 = Vec::new();
+    let mut in_buffer = StorageBuffer::new(&mut in_byte_buffer);
+    let mut in_buffer2 = StorageBuffer::new(&mut in_byte_buffer2);
+    in_buffer.write(&data).unwrap();
+    in_buffer2.write(&data2).unwrap();
+    assert_eq!(in_byte_buffer, in_byte_buffer2);
+}


### PR DESCRIPTION
Mostly resolves the issues found in #53. This PR specializes writes, reads, and creates of types by directly using `slice::copy_from_slice` on them if compiling for a little endian target, and only if the type has no internal padding.

Checking the [generated assembly](https://github.com/james7132/encase_asm_tests/compare/main...direct-copy-specialization#diff-3c8b625b59ff320391d26e84b4ff09bb78fa2722e8265e3e6173572916ae2b30), this eliminates a huge number of branches and even starts using vectorized copies and calls to `memcpy` directly for larger types.