### PR TITLE
Support writing to uninitialized memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,11 @@ let offsets = [
 
 // SAFETY: Vec<u8> and Vec<MaybeUninit<u8>> share the same layout.
 let byte_buffer: Vec<u8> = unsafe { 
-    Vec::from_raw_parts(byte_buffer.as_mut_ptr(), byte_buffer.len(), 
-        byte_buffer.capacity()) 
+    Vec::from_raw_parts(
+        byte_buffer.as_mut_ptr().cast(), 
+        byte_buffer.len(), 
+        byte_buffer.capacity()
+    ) 
 };
 
 // write byte_buffer to GPU

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ let transform = AffineTransform2D {
     translate: glam::Vec2::ZERO,
 };
 
-let mut buffer = UniformBuffer::new(Vec::new());
+let mut buffer = UniformBuffer::new(Vec::<u8>::new());
 buffer.write(&transform).unwrap();
 let byte_buffer = buffer.into_inner();
 
@@ -94,7 +94,7 @@ let mut positions = Positions {
     ])
 };
 
-let mut byte_buffer = Vec::new();
+let mut byte_buffer: Vec<u8> = Vec::new();
 
 let mut buffer = StorageBuffer::new(&mut byte_buffer);
 buffer.write(&positions).unwrap();
@@ -118,7 +118,7 @@ Write different data types to dynamic storage buffer
 ```rust
 use encase::{ShaderType, DynamicStorageBuffer};
 
-let mut byte_buffer = Vec::new();
+let mut byte_buffer: Vec<u8> = Vec::new();
 
 let mut buffer = DynamicStorageBuffer::new_with_alignment(&mut byte_buffer, 64);
 let offsets = [

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ Supports writing to uninitialized memory as well.
 use std::mem::MaybeUninit;
 use encase::{ShaderType, DynamicStorageBuffer};
 
-let mut byte_buffer: Vec<MaybeUninit<u8>> = Vec::new();
+let mut uninit_buffer: Vec<MaybeUninit<u8>> = Vec::new();
 
-let mut buffer = DynamicStorageBuffer::new_with_alignment(&mut byte_buffer, 64);
+let mut buffer = DynamicStorageBuffer::new_with_alignment(&mut uninit_buffer, 64);
 let offsets = [
     buffer.write(&[5.; 10]).unwrap(),
     buffer.write(&vec![3u32; 20]).unwrap(),
@@ -151,11 +151,13 @@ let offsets = [
 // SAFETY: Vec<u8> and Vec<MaybeUninit<u8>> share the same layout.
 let byte_buffer: Vec<u8> = unsafe { 
     Vec::from_raw_parts(
-        byte_buffer.as_mut_ptr().cast(), 
-        byte_buffer.len(), 
-        byte_buffer.capacity()
+        uninit_buffer.as_mut_ptr().cast(), 
+        uninit_buffer.len(), 
+        uninit_buffer.capacity()
     ) 
 };
+
+std::mem::forget(uninit_buffer);
 
 // write byte_buffer to GPU
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,30 @@ assert_eq!(offsets, [0, 64, 192]);
 
 ```
 
+Supports writing to uninitialized memory as well.
+
+```rust
+use std::mem::MaybeUninit;
+use encase::{ShaderType, DynamicStorageBuffer};
+
+let mut byte_buffer: Vec<MaybeUninit<u8>> = Vec::new();
+
+let mut buffer = DynamicStorageBuffer::new_with_alignment(&mut byte_buffer, 64);
+let offsets = [
+    buffer.write(&[5.; 10]).unwrap(),
+    buffer.write(&vec![3u32; 20]).unwrap(),
+    buffer.write(&glam::Vec3::ONE).unwrap(),
+];
+
+// SAFETY: Vec<u8> and Vec<MaybeUninit<u8>> share the same layout.
+let byte_buffer: Vec<u8> = unsafe { std::mem::transmute(byte_buffer) };
+
+// write byte_buffer to GPU
+
+assert_eq!(offsets, [0, 64, 192]);
+
+```
+
 [host-shareable types]: https://gpuweb.github.io/gpuweb/wgsl/#host-shareable-types
 [features]: https://docs.rs/crate/encase/latest/features
 [`ShaderType`]: https://docs.rs/encase/latest/encase/trait.ShaderType.html

--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ let offsets = [
 ];
 
 // SAFETY: Vec<u8> and Vec<MaybeUninit<u8>> share the same layout.
-let byte_buffer: Vec<u8> = unsafe { std::mem::transmute(byte_buffer) };
+let byte_buffer: Vec<u8> = unsafe { 
+    Vec::from_raw_parts(byte_buffer.as_mut_ptr(), byte_buffer.len(), 
+        byte_buffer.capacity()) 
+};
 
 // write byte_buffer to GPU
 

--- a/src/core/rw.rs
+++ b/src/core/rw.rs
@@ -1,4 +1,5 @@
 use super::ShaderType;
+use core::mem::MaybeUninit;
 use thiserror::Error;
 
 #[derive(Clone, Copy, Debug, Error)]
@@ -231,6 +232,21 @@ impl BufferMut for [u8] {
     }
 }
 
+impl BufferMut for [MaybeUninit<u8>] {
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn write<const N: usize>(&mut self, offset: usize, val: &[u8; N]) {
+        use crate::utils::SliceExt;
+        // SAFETY: &[u8; N] and &[MaybeUninit<u8>; N] have the same layout
+        let val: &[MaybeUninit<u8>; N] = unsafe { core::mem::transmute(val) };
+        *self.array_mut(offset) = *val;
+    }
+}
+
 impl<const LEN: usize> BufferMut for [u8; LEN] {
     #[inline]
     fn capacity(&self) -> usize {
@@ -240,6 +256,18 @@ impl<const LEN: usize> BufferMut for [u8; LEN] {
     #[inline]
     fn write<const N: usize>(&mut self, offset: usize, val: &[u8; N]) {
         <[u8] as BufferMut>::write(self, offset, val)
+    }
+}
+
+impl<const LEN: usize> BufferMut for [MaybeUninit<u8>; LEN] {
+    #[inline]
+    fn capacity(&self) -> usize {
+        <[MaybeUninit<u8>] as BufferMut>::capacity(self)
+    }
+
+    #[inline]
+    fn write<const N: usize>(&mut self, offset: usize, val: &[u8; N]) {
+        <[MaybeUninit<u8>] as BufferMut>::write(self, offset, val)
     }
 }
 
@@ -257,7 +285,25 @@ impl BufferMut for Vec<u8> {
     #[inline]
     fn try_enlarge(&mut self, wanted: usize) -> core::result::Result<(), EnlargeError> {
         use crate::utils::ByteVecExt;
-        self.try_extend_zeroed(wanted).map_err(EnlargeError::from)
+        self.try_extend(wanted).map_err(EnlargeError::from)
+    }
+}
+
+impl BufferMut for Vec<MaybeUninit<u8>> {
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.capacity()
+    }
+
+    #[inline]
+    fn write<const N: usize>(&mut self, offset: usize, val: &[u8; N]) {
+        <[MaybeUninit<u8>] as BufferMut>::write(self, offset, val)
+    }
+
+    #[inline]
+    fn try_enlarge(&mut self, wanted: usize) -> core::result::Result<(), EnlargeError> {
+        use crate::utils::ByteVecExt;
+        self.try_extend(wanted).map_err(EnlargeError::from)
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -155,7 +155,7 @@ mod byte_vec_ext {
 
     #[test]
     fn try_extend() {
-        let mut vec = Vec::new();
+        let mut vec: Vec<u8> = Vec::new();
 
         vec.try_extend(10).unwrap();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -154,29 +154,29 @@ mod byte_vec_ext {
     use crate::utils::ByteVecExt;
 
     #[test]
-    fn try_extend_zeroed() {
+    fn try_extend() {
         let mut vec = Vec::new();
 
-        vec.try_extend_zeroed(10).unwrap();
+        vec.try_extend(10).unwrap();
 
         assert_eq!(vec.len(), 10);
         assert!(vec.iter().all(|val| *val == 0));
     }
 
     #[test]
-    fn try_extend_zeroed_noop() {
+    fn try_extend_noop() {
         let mut vec = vec![0; 12];
 
-        vec.try_extend_zeroed(10).unwrap();
+        vec.try_extend(10).unwrap();
 
         assert_eq!(vec.len(), 12);
     }
 
     #[test]
-    fn try_extend_zeroed_err() {
+    fn try_extend_err() {
         let mut vec = vec![0; 12];
 
-        assert!(vec.try_extend_zeroed(usize::MAX).is_err());
+        assert!(vec.try_extend(usize::MAX).is_err());
     }
 }
 


### PR DESCRIPTION
This PR implements BufferMut for slices and Vecs of `MaybeUninit<u8>`. This also implements BytesVecExt provide an implementation that extends the Vec without zeroing out the memory, explicitly for `MaybeUninit<u8>`.