### PR TITLE
Use `docsrs` to detect being built on docs.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     name: Build docs
     runs-on: ubuntu-latest
     env:
-      RUSTDOCFLAGS: --cfg docs
+      RUSTDOCFLAGS: --cfg docsrs
     steps:
       - uses: actions/checkout@v4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["rendering"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docs"]
 
 [profile.bench]
 lto = "thin"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(
     future_incompatible,


### PR DESCRIPTION
As described on <https://docs.rs/about/builds>, the correct way now to check for a build happening at docs.rs is to check for the `docsrs` cfg.

This also prevents Rust 1.80 and later from warning about the `unexpected_cfg` for `docs`.