### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Provides a mechanism to lay out data into GPU buffers ensuring WGSL's memory lay
 ## Features
 
 - supports all WGSL [host-shareable types] + wrapper types (`&T`, `&mut T`, `Box<T>`, ...)
-- supports data types from a multitude of crates as [features]
+- supports data types from a multitude of crates as [features], providing you use the same crate versions `encase` does.
 - covers a wide area of use cases (see [examples](#examples))
 
 ## Motivation


### PR DESCRIPTION
Add a note to the README because the VERSION of a `--feature='xyz'`  crate is **important**.

Example: a `glam::Vec3` on version `0.30.0` is a distinct and entirely different type from `glam::Vec3` on `0.29.0` and the version `encase` is using will be the only one the appropriate stuff is implemented via the fancy macros on.

I imagine I'm not the first to encounter this.

An Extended Example:

1. See this in the examples:
```rust
#[derive(ShaderType)]
struct Positions {
    length: ArrayLength,
    #[size(runtime)]
    positions: Vec<mint::Point3<f32>>
}
```
0 problems.

2. See that `glam` is a feature, so slap it in there!
>Cargo.toml
```toml
#... snipping...
encase = { version = "0.10.0", features = ["glam"] }
glam = "0.30.0" # Here is the problem you may not see coming, as glam was already a dep in this project...
```

```rust
#[derive(ShaderType)]
struct Positions {
    length: ArrayLength,
    #[size(runtime)]
    positions: Vec<glam::Vec3>
}
```
3. Get an error. 
```
error[E0277]: the trait bound `Vec3: ShaderSize` is not satisfied
  --> src/gpu_image.rs:27:16
   |
27 |     positions: Vec<Vec3>,
   |                ^^^^^^^^^ the trait `ShaderSize` is not implemented for `Vec3`
   |
   = help: the following other types implement trait `ShaderSize`:
             &T
             &mut T
             Arc<T>
             AtomicI32
             AtomicU32
             Box<T>
             Cell<T>
             Cow<'_, T>
           and 22 others
   = note: required for `Vec<Vec3>` to implement `ShaderType`
```
4. Faff about for halfa until you realise `encase` is using `glam = "0.29.0"`
5. Use the same version as `encase`.
>Cargo.toml
```toml
#... snipping...
encase = { version = "0.10.0", features = ["glam"] }
glam = "0.29.0" 
```
6. code compiles fine.

The insidious thing here is that obviously `rust-analyzer` or `rustc` won't tell you that it's a distinct types from differing versions of crates issue.

