### PR TITLE
Update all dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
-  NIGHTLY: nightly-2023-12-28
+  NIGHTLY: nightly-2025-03-18
 
 jobs:
   msrv_and_minimal_versions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "encase"
 version = "0.10.0"
 edition = "2021"
-rust-version = "1.68.2"
+rust-version = "1.77"
 
 license = "MIT-0"
 readme = "./README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,31 +30,31 @@ members = ["derive", "derive/impl"]
 [dependencies]
 encase_derive = { version = "=0.10.0", path = "derive" }
 
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false }
 const_panic = { version = "0.2", default-features = false }
 
 mint = { version = "0.5.9", default-features = false, optional = true }
 cgmath = { version = "0.18", default-features = false, optional = true }
-glam = { version = "0.29", features = ["std"], default-features = false, optional = true }
+glam = { version = "0.30", features = ["std"], default-features = false, optional = true }
 nalgebra = { version = "0.33", default-features = false, optional = true }
 ultraviolet = { version = "0.9", features = ["int"], default-features = false, optional = true }
 vek = { version = "0.17", default-features = false, optional = true }
 smallvec = { version = "1.8.0", features = ["const_generics"], default-features = false, optional = true }
 arrayvec = { version = "0.7", default-features = false, optional = true }
 tinyvec = { version = "1.4", features = ["rustc_1_55", "alloc"], default-features = false, optional = true }
-ndarray = { version = "0.15", default-features = false, optional = true }
+ndarray = { version = "0.16", default-features = false, optional = true }
 rpds = { version = "1", default-features = false, optional = true }
 archery = { version = "1", default-features = false, optional = true }
 im = { version = "15", default-features = false, optional = true }
 im-rc = { version = "15", default-features = false, optional = true }
-imbl = { version = "3", default-features = false, optional = true }
+imbl = { version = "5", default-features = false, optional = true }
 static-rc = { version = "0.6", features = ["alloc"], default-features = false, optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.4", features = ["cargo_bench_support", "html_reports"], default-features = false }
-rand = { version = "0.8", features = ["std_rng"], default-features = false }
+criterion = { version = "0.5", features = ["cargo_bench_support", "html_reports"], default-features = false }
+rand = { version = "0.9", features = ["std_rng"], default-features = false }
 mimalloc = { version = "0.1", default-features = false }
-wgpu = { version = "22.0.0", features = ["wgsl"] }
+wgpu = { version = "24.0", features = ["wgsl"] }
 futures = { version = "0.3", features = ["executor"], default-features = false }
-pprof = { version = "0.11", features = ["criterion", "flamegraph"], default-features = false }
+pprof = { version = "0.14", features = ["criterion", "flamegraph"], default-features = false }
 trybuild = { version = "1", default-features = false }

--- a/tests/hygiene.rs
+++ b/tests/hygiene.rs
@@ -21,17 +21,17 @@ mod impl_vector {
         data: PhantomData<&'a T>,
     }
 
-    impl<'a, T, const N: usize> AsRef<[T; N]> for Test<'a, T> {
+    impl<T, const N: usize> AsRef<[T; N]> for Test<'_, T> {
         fn as_ref(&self) -> &[T; N] {
             unimplemented!()
         }
     }
-    impl<'a, T, const N: usize> AsMut<[T; N]> for Test<'a, T> {
+    impl<T, const N: usize> AsMut<[T; N]> for Test<'_, T> {
         fn as_mut(&mut self) -> &mut [T; N] {
             unimplemented!()
         }
     }
-    impl<'a, T, const N: usize> From<[T; N]> for Test<'a, T> {
+    impl<T, const N: usize> From<[T; N]> for Test<'_, T> {
         fn from(_: [T; N]) -> Self {
             unimplemented!()
         }
@@ -51,17 +51,17 @@ mod impl_matrix {
         data: PhantomData<&'a T>,
     }
 
-    impl<'a, T, const N: usize, const M: usize> AsRef<[[T; M]; N]> for Test<'a, T> {
+    impl<T, const N: usize, const M: usize> AsRef<[[T; M]; N]> for Test<'_, T> {
         fn as_ref(&self) -> &[[T; M]; N] {
             unimplemented!()
         }
     }
-    impl<'a, T, const N: usize, const M: usize> AsMut<[[T; M]; N]> for Test<'a, T> {
+    impl<T, const N: usize, const M: usize> AsMut<[[T; M]; N]> for Test<'_, T> {
         fn as_mut(&mut self) -> &mut [[T; M]; N] {
             unimplemented!()
         }
     }
-    impl<'a, T, const N: usize, const M: usize> From<[[T; M]; N]> for Test<'a, T> {
+    impl<T, const N: usize, const M: usize> From<[[T; M]; N]> for Test<'_, T> {
         fn from(_: [[T; M]; N]) -> Self {
             unimplemented!()
         }

--- a/tests/wgpu.rs
+++ b/tests/wgpu.rs
@@ -157,9 +157,8 @@ fn in_out<IN: encase::ShaderType, OUT: encase::ShaderType>(
     data: &[u8],
     is_uniform: bool,
 ) -> Vec<u8> {
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
         backends: wgpu::Backends::PRIMARY,
-        dx12_shader_compiler: wgpu::Dx12Compiler::Fxc,
         ..Default::default()
     });
     let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
@@ -235,7 +234,7 @@ fn in_out<IN: encase::ShaderType, OUT: encase::ShaderType>(
         label: None,
         layout: Some(&pipeline_layout),
         module: &shader,
-        entry_point: "main",
+        entry_point: Some("main"),
         compilation_options: wgpu::PipelineCompilationOptions::default(),
         cache: None,
     });


### PR DESCRIPTION
Encompasses #86 and #88, along with bumping wgpu and imbl. In doing so, also bumps the MSRV to 1.77 (Mar. 21, 2024).