### PR TITLE
fix clippy lint about unsatisfied bounds on Self

### DIFF
--- a/src/types/runtime_sized_array.rs
+++ b/src/types/runtime_sized_array.rs
@@ -246,7 +246,7 @@ macro_rules! impl_rts_array_inner {
     };
 }
 
-impl_rts_array!([T]; using len);
+impl_rts_array!(&[T]; using len);
 impl_rts_array!(Vec<T>; using len truncate);
 impl_rts_array!(VecDeque<T>; using len truncate);
 impl_rts_array!(LinkedList<T>; using len);


### PR DESCRIPTION
Clippy gives a warning:
```
warning: this item cannot be used as its where bounds are not satisfied for the `Self` type
   --> src/types/runtime_sized_array.rs:229:13
    |
229 |             fn create_from<B: $crate::private::BufferRef>(reader: &mut $crate::private::Reader<B>) -> Self {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
249 | impl_rts_array!([T]; using len);
    | ------------------------------- in this macro invocation
```

Fixes https://github.com/teoxoy/encase/issues/91.