### PR TITLE
Use `shader()` attribute with size/align as arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Rename `align` attribute of `ShaderType` to `shader_align`
+- Place `align`/`size` inside a `shader()` attribute instead of being free-floating
 
 ## v0.11.2 (2025-08-25)
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ use encase::{ShaderType, ArrayLength, StorageBuffer};
 #[derive(ShaderType)]
 struct Positions {
     length: ArrayLength,
-    #[size(runtime)]
+    #[shader(size(runtime))]
     positions: Vec<mint::Point2<f32>>
 }
 

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -64,7 +64,7 @@ struct A {
     arrm2: [mint::ColumnMatrix2<f32>; 8],
     arrm3: [mint::ColumnMatrix3<f32>; 8],
     arrm4: [mint::ColumnMatrix4<f32>; 8],
-    #[size(1600)]
+    #[shader(size(1600))]
     _pad: u32,
 }
 

--- a/derive/impl/Cargo.toml
+++ b/derive/impl/Cargo.toml
@@ -11,6 +11,6 @@ keywords = ["wgsl", "wgpu"]
 categories = ["rendering"]
 
 [dependencies]
-syn = "2.0.1"
+syn = { version = "2.0.1", features = ["extra-traits"] }
 quote = "1"
 proc-macro2 = "1"

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -148,7 +148,7 @@ pub trait ShaderType {
     /// # use mint;
     /// #[derive(ShaderType)]
     /// struct Invalid {
-    ///     #[size(runtime)]
+    ///     #[shader(size(runtime))]
     ///     vec: Vec<mint::Vector4<f32>>
     /// }
     /// Invalid::assert_uniform_compat();
@@ -171,7 +171,7 @@ pub trait ShaderType {
     /// Invalid::assert_uniform_compat();
     /// ```
     ///
-    /// Will not panic (fixed via shader_align attribute)
+    /// Will not panic (fixed via #[shader(align)] attribute)
     ///
     /// ```
     /// # use crate::encase::ShaderType;
@@ -182,7 +182,7 @@ pub trait ShaderType {
     /// #[derive(ShaderType)]
     /// struct Valid {
     ///     a: f32,
-    ///     #[shader_align(16)]
+    ///     #[shader(align(16))]
     ///     b: S,
     /// }
     /// Valid::assert_uniform_compat();
@@ -198,7 +198,7 @@ pub trait ShaderType {
     /// # }
     /// #[derive(ShaderType)]
     /// struct Valid {
-    ///     #[size(16)]
+    ///     #[shader(size(16))]
     ///     a: f32,
     ///     b: S,
     /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,15 +26,15 @@
 ///
 /// Field attributes
 ///
-/// - `#[shader_align(X)]` where `X` is a power of 2 [`u32`] literal (equivalent to [WGSL align attribute](https://gpuweb.github.io/gpuweb/wgsl/#attribute-align))
+/// - `#[shader(align(X))]` where `X` is a power of 2 [`u32`] literal (equivalent to [WGSL align attribute](https://gpuweb.github.io/gpuweb/wgsl/#attribute-align))
 ///
 ///     Used to increase the alignment of the field
 ///
-/// - `#[size(X)]` where `X` is a [`u32`] literal (equivalent to [WGSL size attribute](https://gpuweb.github.io/gpuweb/wgsl/#attribute-size))
+/// - `#[shader(size(X))]` where `X` is a [`u32`] literal (equivalent to [WGSL size attribute](https://gpuweb.github.io/gpuweb/wgsl/#attribute-size))
 ///
 ///     Used to increase the size of the field
 ///
-/// - `#[size(runtime)]` can only be attached to the last field of the struct
+/// - `#[shader(size(runtime))]` can only be attached to the last field of the struct
 ///
 ///     Used to denote the fact that the field it is attached to is a runtime-sized array
 ///
@@ -42,7 +42,7 @@
 ///
 /// While structs using generic type parameters are supported by this derive macro
 ///
-/// - the `#[shader_align(X)]` and `#[size(X)]` attributes will only work
+/// - the `#[shader(align(X))]` and `#[shader(size(X))]` attributes will only work
 ///   if they are attached to fields whose type contains no generic type parameters
 ///
 /// # Examples
@@ -70,7 +70,7 @@
 /// #[derive(ShaderType)]
 /// struct Positions {
 ///     length: ArrayLength,
-///     #[size(runtime)]
+///     #[shader(size(runtime))]
 ///     positions: Vec<mint::Point2<f32>>
 /// }
 /// ```
@@ -88,7 +88,7 @@
 ///     const N: usize,
 /// > {
 ///     array: [&'a mut E; N],
-///     #[size(runtime)]
+///     #[shader(size(runtime))]
 ///     rts_array: &'a mut Vec<&'b T>,
 /// }
 /// ```

--- a/tests/assert_uniform_compat_fail.rs
+++ b/tests/assert_uniform_compat_fail.rs
@@ -7,7 +7,7 @@ struct S {
 
 #[derive(ShaderType)]
 struct WrappedF32 {
-    #[size(16)]
+    #[shader(size(16))]
     elem: f32,
 }
 
@@ -63,7 +63,7 @@ fn test_array_stride() {
 fn test_rts_array() {
     #[derive(ShaderType)]
     struct TestRTSArray {
-        #[size(runtime)]
+        #[shader(size(runtime))]
         a: Vec<f32>,
     }
 

--- a/tests/assert_uniform_compat_success.rs
+++ b/tests/assert_uniform_compat_success.rs
@@ -7,28 +7,28 @@ struct S {
 
 #[derive(ShaderType)]
 struct WrappedF32 {
-    #[size(16)]
+    #[shader(size(16))]
     elem: f32,
 }
 
 #[derive(ShaderType)]
 struct TestStruct {
     a: u32,
-    #[shader_align(16)]
+    #[shader(align(16))]
     b: S,
 }
 
 #[derive(ShaderType)]
 struct TestArray {
     a: u32,
-    #[shader_align(16)]
+    #[shader(align(16))]
     b: [WrappedF32; 1],
 }
 
 #[derive(ShaderType)]
 struct TestStructFirst {
     a: S,
-    #[shader_align(16)]
+    #[shader(align(16))]
     b: f32,
 }
 

--- a/tests/compile_fail/array_length_err.stderr
+++ b/tests/compile_fail/array_length_err.stderr
@@ -1,4 +1,4 @@
-error: `ArrayLength` type can only be used within a struct containing a runtime-sized array marked as `#[size(runtime)]`!
+error: `ArrayLength` type can only be used within a struct containing a runtime-sized array marked as `#[shader(size(runtime))]`!
  --> tests/compile_fail/array_length_err.rs:7:8
   |
 7 |     a: ArrayLength,

--- a/tests/compile_fail/invalid_align_attr.rs
+++ b/tests/compile_fail/invalid_align_attr.rs
@@ -4,12 +4,12 @@ fn main() {}
 
 #[derive(ShaderType)]
 struct Test {
-    #[shader_align]
+    #[shader(align)]
     a: u32,
-    #[shader_align()]
+    #[shader(align())]
     b: u32,
-    #[shader_align(invalid)]
+    #[shader(align(invalid))]
     c: u32,
-    #[shader_align(3)]
+    #[shader(align(3))]
     d: u32,
 }

--- a/tests/compile_fail/invalid_align_attr.stderr
+++ b/tests/compile_fail/invalid_align_attr.stderr
@@ -1,23 +1,23 @@
-error: expected attribute arguments in parentheses: `shader_align(...)`
- --> tests/compile_fail/invalid_align_attr.rs:7:7
+error: expected attribute arguments in parentheses: `align(...)`
+ --> tests/compile_fail/invalid_align_attr.rs:7:14
   |
-7 |     #[shader_align]
-  |       ^^^^^^^^^^^^
+7 |     #[shader(align)]
+  |              ^^^^^
 
 error: expected a power of 2 u32 literal
  --> tests/compile_fail/invalid_align_attr.rs:9:20
   |
-9 |     #[shader_align()]
+9 |     #[shader(align())]
   |                    ^
 
 error: expected a power of 2 u32 literal
   --> tests/compile_fail/invalid_align_attr.rs:11:20
    |
-11 |     #[shader_align(invalid)]
+11 |     #[shader(align(invalid))]
    |                    ^^^^^^^
 
 error: expected a power of 2 u32 literal
   --> tests/compile_fail/invalid_align_attr.rs:13:21
    |
-13 |     #[shader_align(3)]
+13 |     #[shader(align(3))]
    |                     ^

--- a/tests/compile_fail/invalid_size_attr.rs
+++ b/tests/compile_fail/invalid_size_attr.rs
@@ -4,12 +4,12 @@ fn main() {}
 
 #[derive(ShaderType)]
 struct Test {
-    #[size]
+    #[shader(size)]
     a: u32,
-    #[size()]
+    #[shader(size())]
     b: u32,
-    #[size(invalid)]
+    #[shader(size(invalid))]
     c: u32,
-    #[size(-1)]
+    #[shader(size(-1))]
     d: u32,
 }

--- a/tests/compile_fail/invalid_size_attr.stderr
+++ b/tests/compile_fail/invalid_size_attr.stderr
@@ -1,23 +1,23 @@
 error: expected attribute arguments in parentheses: `size(...)`
- --> tests/compile_fail/invalid_size_attr.rs:7:7
+ --> tests/compile_fail/invalid_size_attr.rs:7:14
   |
-7 |     #[size]
-  |       ^^^^
-
-error: expected u32 literal
- --> tests/compile_fail/invalid_size_attr.rs:9:12
-  |
-9 |     #[size()]
-  |            ^
-
-error: expected u32 literal
-  --> tests/compile_fail/invalid_size_attr.rs:11:12
-   |
-11 |     #[size(invalid)]
-   |            ^^^^^^^
+7 |     #[shader(size)]
+  |              ^^^^
 
 error: expected u32 literal or `runtime` identifier
-  --> tests/compile_fail/invalid_size_attr.rs:13:14
+ --> tests/compile_fail/invalid_size_attr.rs:9:19
+  |
+9 |     #[shader(size())]
+  |                   ^
+
+error: expected u32 literal or `runtime` identifier
+  --> tests/compile_fail/invalid_size_attr.rs:11:19
    |
-13 |     #[size(-1)]
-   |              ^
+11 |     #[shader(size(invalid))]
+   |                   ^^^^^^^
+
+error: expected u32 literal or `runtime` identifier
+  --> tests/compile_fail/invalid_size_attr.rs:13:19
+   |
+13 |     #[shader(size(-1))]
+   |                   ^

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -62,7 +62,7 @@ struct A {
     arrm3: [mint::ColumnMatrix3<f32>; 8],
     arrm4: [mint::ColumnMatrix4<f32>; 8],
     rt_arr_len: ArrayLength,
-    #[size(runtime)]
+    #[shader(size(runtime))]
     rt_arr: Vec<mint::ColumnMatrix2x3<f32>>,
 }
 

--- a/tests/hygiene.rs
+++ b/tests/hygiene.rs
@@ -106,10 +106,9 @@ struct TestGeneric<
     T: 'a + ::encase::ShaderType + ::encase::ShaderSize,
     const N: ::core::primitive::usize,
 > {
-    #[size(90)]
+    #[shader(size(90))]
     a: &'a mut Test,
     b: &'a mut [T; N],
-    #[shader_align(16)]
-    #[size(runtime)]
+    #[shader(align(16), size(runtime))]
     c: &'a mut ::std::vec::Vec<[::mint::Vector3<::core::primitive::f32>; 2]>,
 }

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -2,7 +2,7 @@ use encase::ShaderType;
 
 #[derive(ShaderType)]
 struct WrappedF32 {
-    #[size(16)]
+    #[shader(size(16), align(16))]
     value: f32,
 }
 

--- a/tests/pass/attributes.rs
+++ b/tests/pass/attributes.rs
@@ -4,18 +4,17 @@ fn main() {}
 
 #[derive(ShaderType)]
 struct TestAttributes {
-    #[shader_align(16)]
+    #[shader(align(16))]
     a: u32,
-    #[size(8)]
+    #[shader(size(8))]
     b: u32,
 }
 
 #[derive(ShaderType)]
 struct TestRtArray {
-    #[size(8)]
+    #[shader(size(8))]
     a: u32,
-    #[shader_align(16)]
-    #[size(runtime)]
+    #[shader(align(16), size(runtime))]
     b: Vec<u32>,
 }
 

--- a/tests/wgpu.rs
+++ b/tests/wgpu.rs
@@ -10,8 +10,7 @@ struct A {
     u: u32,
     v: u32,
     w: Vector2<u32>,
-    #[size(16)]
-    #[shader_align(8)]
+    #[shader(size(16), align(8))]
     x: u32,
     xx: u32,
 }
@@ -22,13 +21,12 @@ struct B {
     b: Vector3<u32>,
     c: u32,
     d: u32,
-    #[shader_align(16)]
+    #[shader(align(16))]
     e: A,
     f: Vector3<u32>,
     g: [A; 3],
     h: i32,
-    #[shader_align(32)]
-    #[size(runtime)]
+    #[shader(align(32), size(runtime))]
     i: Vec<A>,
 }
 
@@ -123,8 +121,7 @@ fn array_length() {
         array_length: ArrayLength,
         array_length_call_ret_val: u32,
         a: Vector3<u32>,
-        #[shader_align(16)]
-        #[size(runtime)]
+        #[shader(align(16), size(runtime))]
         arr: Vec<u32>,
     }
 


### PR DESCRIPTION
Same goal as https://github.com/teoxoy/encase/pull/99
Just to change it to `#[shader(align, size(..))]` instead of `#[shader_align]/#[size(..)]`