### PR TITLE
Allow dead_code lint for Rust v1.89 in derive macro output

### DIFF
--- a/derive/impl/src/lib.rs
+++ b/derive/impl/src/lib.rs
@@ -324,6 +324,7 @@ pub fn derive_shader_type(input: DeriveInput, root: &Path) -> TokenStream {
                 quote_spanned! {*span=>
                     const _: () = {
                         #[track_caller]
+                        #[allow(dead_code)]
                         #[allow(clippy::extra_unused_lifetimes)]
                         const fn check #impl_generics () {
                             let size = <#ty as #root::ShaderSize>::SHADER_SIZE.get();


### PR DESCRIPTION
Fix #102. Adds an allow lint to generated derive macro code.