### PR TITLE
Migrate to `doc_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(
     clippy::semicolon_if_nothing_returned,


### PR DESCRIPTION
It is not yet causing problems, but future builds on docs.rs won't work.

https://github.com/rust-lang/rust/pull/138907