### PR TITLE
Add `no_std` support

### DIFF
--- a/src/core/alignment_value.rs
+++ b/src/core/alignment_value.rs
@@ -80,6 +80,7 @@ impl AlignmentValue {
 #[cfg(test)]
 mod test {
     use super::AlignmentValue;
+    use alloc::format;
 
     #[test]
     fn new() {

--- a/src/core/rw.rs
+++ b/src/core/rw.rs
@@ -1,4 +1,6 @@
 use super::ShaderType;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 use thiserror::Error;
 
@@ -177,8 +179,8 @@ impl<B: BufferMut> Cursor<B> {
 #[error("could not enlarge buffer")]
 pub struct EnlargeError;
 
-impl From<std::collections::TryReserveError> for EnlargeError {
-    fn from(_: std::collections::TryReserveError) -> Self {
+impl From<alloc::collections::TryReserveError> for EnlargeError {
+    fn from(_: alloc::collections::TryReserveError) -> Self {
         Self
     }
 }
@@ -401,7 +403,7 @@ macro_rules! impl_buffer_ref_for_wrappers {
     )*};
 }
 
-impl_buffer_ref_for_wrappers!(&T, &mut T, Box<T>, std::rc::Rc<T>, std::sync::Arc<T>);
+impl_buffer_ref_for_wrappers!(&T, &mut T, Box<T>, alloc::rc::Rc<T>, alloc::sync::Arc<T>);
 
 macro_rules! impl_buffer_mut_for_wrappers {
     ($($type:ty),*) => {$(
@@ -434,6 +436,7 @@ impl_buffer_mut_for_wrappers!(&mut T, Box<T>);
 #[cfg(test)]
 mod buffer_ref {
     use super::BufferRef;
+    use alloc::vec::Vec;
 
     #[test]
     fn array() {
@@ -456,6 +459,7 @@ mod buffer_ref {
 mod buffer_mut {
     use super::BufferMut;
     use crate::core::EnlargeError;
+    use alloc::vec::Vec;
 
     #[test]
     fn array() {
@@ -493,6 +497,7 @@ mod buffer_mut {
 #[cfg(test)]
 mod error {
     use super::Error;
+    use alloc::format;
 
     #[test]
     fn derived_traits() {
@@ -502,7 +507,7 @@ mod error {
         };
 
         {
-            use std::error::Error;
+            use core::error::Error;
             assert!(err.source().is_none());
         }
 
@@ -521,6 +526,8 @@ mod error {
 #[cfg(test)]
 mod enlarge_error {
     use super::EnlargeError;
+    use alloc::format;
+    use alloc::vec::Vec;
 
     #[test]
     fn derived_traits() {
@@ -531,7 +538,7 @@ mod enlarge_error {
         };
         let err = EnlargeError::from(try_reserve_error);
 
-        use std::error::Error;
+        use core::error::Error;
         assert!(err.source().is_none());
 
         assert_eq!(format!("{}", err.clone()), "could not enlarge buffer");

--- a/src/core/size_value.rs
+++ b/src/core/size_value.rs
@@ -41,6 +41,7 @@ impl SizeValue {
 #[cfg(test)]
 mod test {
     use super::SizeValue;
+    use alloc::format;
 
     #[test]
     fn new() {

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU64;
+use core::num::NonZeroU64;
 
 use super::{AlignmentValue, BufferMut, BufferRef, Reader, SizeValue, Writer};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/teoxoy/encase/3d6d2e4d7670863e97463a15ceeafac6d13ee73e/logo.svg"
 )]
+#![no_std]
+
+extern crate alloc;
 
 /// Used to implement `ShaderType` for structs
 ///

--- a/src/types/runtime_sized_array.rs
+++ b/src/types/runtime_sized_array.rs
@@ -1,4 +1,5 @@
-use std::collections::{LinkedList, VecDeque};
+use alloc::collections::{LinkedList, VecDeque};
+use alloc::vec::Vec;
 
 use crate::core::{
     BufferMut, BufferRef, CreateFrom, Metadata, ReadFrom, Reader, RuntimeSizedArray, ShaderSize,
@@ -263,6 +264,7 @@ impl<T> Truncate for LinkedList<T> {
 #[cfg(test)]
 mod array_length {
     use super::ArrayLength;
+    use alloc::format;
 
     #[test]
     fn derived_traits() {

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -121,7 +121,7 @@ macro_rules! impl_traits_for_atomic {
         impl WriteInto for $type {
             #[inline]
             fn write_into<B: BufferMut>(&self, writer: &mut Writer<B>) {
-                let value = self.load(std::sync::atomic::Ordering::Relaxed);
+                let value = self.load(core::sync::atomic::Ordering::Relaxed);
                 WriteInto::write_into(&value, writer);
             }
         }

--- a/src/types/wrapper.rs
+++ b/src/types/wrapper.rs
@@ -1,3 +1,5 @@
+use alloc::borrow::ToOwned;
+
 /// Used to implement `ShaderType` for the given wrapper type
 ///
 /// # Args
@@ -113,8 +115,8 @@ macro_rules! impl_wrapper_inner {
 
 impl_wrapper!(&T; using Ref{});
 impl_wrapper!(&mut T; using Ref{} Mut{});
-impl_wrapper!(Box<T>; using Ref{} Mut{} From{ new });
-impl_wrapper!(std::borrow::Cow<'_, T>; (T: ?Sized + ToOwned<Owned = T>); using Ref{} From{ Owned });
-impl_wrapper!(std::rc::Rc<T>; using Ref{} From{ new });
-impl_wrapper!(std::sync::Arc<T>; using Ref{} From{ new });
+impl_wrapper!(alloc::boxed::Box<T>; using Ref{} Mut{} From{ new });
+impl_wrapper!(alloc::borrow::Cow<'_, T>; (T: ?Sized + ToOwned<Owned = T>); using Ref{} From{ Owned });
+impl_wrapper!(alloc::rc::Rc<T>; using Ref{} From{ new });
+impl_wrapper!(alloc::sync::Arc<T>; using Ref{} From{ new });
 impl_wrapper!(core::cell::Cell<T>; (T: Copy); using Ref{ .get() } Mut{ .get_mut() } From{ new });

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
 #[track_caller]
@@ -47,12 +48,12 @@ macro_rules! if_pod_and_little_endian {
 
 pub(crate) trait ByteVecExt {
     /// Tries to extend `self` with `0`s up to `new_len`, using memset.
-    fn try_extend(&mut self, new_len: usize) -> Result<(), std::collections::TryReserveError>;
+    fn try_extend(&mut self, new_len: usize) -> Result<(), alloc::collections::TryReserveError>;
 }
 
 impl ByteVecExt for Vec<u8> {
     #[inline]
-    fn try_extend(&mut self, new_len: usize) -> Result<(), std::collections::TryReserveError> {
+    fn try_extend(&mut self, new_len: usize) -> Result<(), alloc::collections::TryReserveError> {
         let additional = new_len.saturating_sub(self.len());
         if additional > 0 {
             self.try_reserve(additional)?;
@@ -73,7 +74,7 @@ impl ByteVecExt for Vec<u8> {
 
 impl<T> ByteVecExt for Vec<MaybeUninit<T>> {
     #[inline]
-    fn try_extend(&mut self, new_len: usize) -> Result<(), std::collections::TryReserveError> {
+    fn try_extend(&mut self, new_len: usize) -> Result<(), alloc::collections::TryReserveError> {
         let additional = new_len.saturating_sub(self.len());
         if additional > 0 {
             self.try_reserve(additional)?;
@@ -136,6 +137,8 @@ impl<T> SliceExt<T> for [T] {
 #[cfg(test)]
 mod byte_vec_ext {
     use crate::utils::ByteVecExt;
+    use alloc::vec;
+    use alloc::vec::Vec;
 
     #[test]
     fn try_extend() {

--- a/tests/hygiene.rs
+++ b/tests/hygiene.rs
@@ -17,6 +17,7 @@ mod impl_vector {
         unimplemented,
     };
 
+    #[expect(dead_code)]
     pub struct Test<'a, T> {
         data: PhantomData<&'a T>,
     }
@@ -47,6 +48,7 @@ mod impl_matrix {
         unimplemented,
     };
 
+    #[expect(dead_code)]
     pub struct Test<'a, T> {
         data: PhantomData<&'a T>,
     }
@@ -100,6 +102,7 @@ struct Test {
     b: ::core::primitive::u32,
 }
 
+#[expect(dead_code)]
 #[derive(::encase::ShaderType)]
 struct TestGeneric<
     'a,


### PR DESCRIPTION
# Description

- Fixes #106
- Supersedes #107

## Details

Made the crate unconditionally `no_std` with no new feature gates. Unlike #107, this doesn't also add `no_alloc` support with a feature gate in order to ensure this PR could be published as a patch release. No functionality has changed, just replaced `std` imports with `alloc` and `core`.

I took up creating this PR after working on `no_std` support for `wgpu` in gfx-rs/wgpu#9859.

The second commit resolves the Clippy `dead_code` warnings which are unrelated to this PR, but trivial enough to not bother separating. Happy to do so if that's a concern!

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.